### PR TITLE
EDM-568: Local demo updates

### DIFF
--- a/api/v1alpha1/openapi.yml
+++ b/api/v1alpha1/openapi.yml
@@ -62,6 +62,11 @@ paths:
           schema:
             type: integer
             format: int32
+        - name: repository
+          in: query
+          description: The name of the repository to filter results by.
+          schema:
+            type: string
       responses:
         "200":
           description: OK
@@ -603,6 +608,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: summaryOnly
+          in: query
+          description: A boolean flag to include only a summary of the devices. When set to true, the response will contain only the summary information. Only the 'owner' and 'labelSelector' parameters are supported when 'summaryOnly' is true.
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -1008,6 +1019,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/enrollmentconfig/{name}:
+    get:
+      tags:
+        - enrollmentconfig
+      description: Get config for enrolling devices
+      operationId: enrollmentConfig
+      parameters:
+        - name: name
+          in: path
+          description: the name of approved CSR
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentConfig'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/enrollmentrequests:
     get:
       tags:
@@ -1349,6 +1398,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/certificatesigningrequests:
     get:
       tags:
@@ -1650,6 +1705,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CertificateSigningRequest'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         "401":
           description: Unauthorized
           content:
@@ -1664,6 +1725,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         "409":
           description: StatusConflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: InternalServerError
           content:
             application/json:
               schema:
@@ -1735,6 +1802,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: addDevicesCount
+          in: query
+          description: include the number of devices in each fleet
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -2442,6 +2515,10 @@ components:
                   type: string
                 path:
                   type: string
+                mountPath:
+                  description: Path to config in device
+                  type: string
+                  default: "/"
               required:
                 - repository
                 - targetRevision
@@ -2474,10 +2551,41 @@ components:
         - type: object
           properties:
             inline:
-              type: object
-              additionalProperties: true
+              type: array
+              items:
+                $ref: '#/components/schemas/FileSpec'
           required:
           - inline
+    FileSpec:
+      type: object
+      properties:
+        path:
+          type: string
+          description: The absolute path to the file on the device. Note that any existing file will be overwritten.
+        content:
+          type: string
+          description: The plain text (UTF-8) or base64-encoded content of the file.
+        contentEncoding:
+          type: string
+          description: How the contents are encoded. Must be either "plain" or "base64". Defaults to "plain".
+          enum:
+          - plain
+          - base64
+        mode:
+          type: integer
+          description: |
+            The file’s permission mode. You may specify the more familiar octal with a leading zero (e.g., 0644) or as
+            a decimal without a leading zero (e.g., 420). Setuid/setgid/sticky bits are supported. If not specified,
+            the permission mode for files defaults to 0644.
+        user:
+          type: string
+          description: The file's owner, specified either as a name or numeric ID. Defaults to "root".
+        group:
+          type: string
+          description: The file's group, specified either as a name or numeric ID. Defaults to "root".
+      required:
+      - path
+      - content
     HttpConfigProviderSpec:
       allOf:
         - $ref: '#/components/schemas/GenericConfigSpec'
@@ -2504,6 +2612,44 @@ components:
               - filePath
           required:
           - httpRef
+    ApplicationSpec:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ApplicationEnvVars'
+        - type: object
+          properties:
+            name:
+              type: string
+              description: "The name of the application"
+        - oneOf:
+            - $ref: '#/components/schemas/ImageApplicationProvider'
+            # extend application providers
+    ImageApplicationProvider:
+      type: object
+      properties:
+        image:
+          type: string
+          description: "Reference to the container image for the application package"
+      required:
+        - image
+    ApplicationEnvVars:
+      type: object
+      properties:
+        envVars:
+          type: object
+          description: "Environment variable key-value pairs, injected during runtime"
+          additionalProperties:
+            type: string
+    RenderedApplicationSpec:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ApplicationEnvVars'
+        - type: object
+          properties:
+            name:
+              type: string
+        - oneOf:
+            - $ref: '#/components/schemas/ImageApplicationProvider'
     ResourceMonitor:
       oneOf:
         - $ref: '#/components/schemas/CPUResourceMonitorSpec'
@@ -2527,8 +2673,8 @@ components:
           description: "Array of alert rules. Only one alert per severity is allowed."
         samplingInterval:
           type: string
-          pattern: '^[1-9]\d*[smhd]$'
-          description: "Duration between monitor samples. Format: number followed by 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days. Must be a positive integer."
+          pattern: '^[1-9]\d*[smh]$'
+          description: "Duration between monitor samples. Format: positive integer followed by 's' for seconds, 'm' for minutes, 'h' for hours."
       required:
         - monitorType
         - alertRules
@@ -2567,8 +2713,8 @@ components:
           description: "Severity of the alert."
         duration:
           type: string
-          pattern: '^\d+[smhd]$'
-          description: "Duration is the time over which the average usage is observed before alerting. Format: number followed by 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days."
+          pattern: '^\d+[smh]$'
+          description: "Duration is the time over which the average usage is observed before alerting. Format: positive integer followed by 's' for seconds, 'm' for minutes, 'h' for hours."
         percentage:
           type: number
           description: 'The percentage of usage that triggers the alert.'
@@ -2596,7 +2742,7 @@ components:
         name:
           type: string
         description:
-          type: string
+          type: string 
         actions:
           type: array
           items:
@@ -2617,7 +2763,7 @@ components:
         name:
           type: string
         description:
-          type: string
+          type: string 
         actions:
           type: array
           items:
@@ -2632,10 +2778,12 @@ components:
         - "Create"
         - "Remove"
         - "Update"
+        - "Reboot"
       x-enum-varnames:
         - "FileOperationCreate"
         - "FileOperationRemove" # by convention remove is fired before the file is removed.
         - "FileOperationUpdate"
+        - "FileOperationReboot"
     HookAction:
       type: object
       oneOf:
@@ -2656,8 +2804,8 @@ components:
              type: string
              pattern: '^[1-9]\d*[smhd]$'
              description: |
-              The maximum duration allowed for the action to complete.
-              The duration should be specified as a positive integer
+              The maximum duration allowed for the action to complete. 
+              The duration should be specified as a positive integer 
               followed by a time unit. Supported time units are:
               - 's' for seconds
               - 'm' for minutes
@@ -2704,7 +2852,7 @@ components:
             description: 'The directory in which the executable will be run from if it is left empty it will run from the users home directory.'
       required:
         - name
-        - operations
+        - operations 
     HookActionExecutableSpec:
       allOf:
         - $ref: '#/components/schemas/HookActionSpec'
@@ -2715,7 +2863,7 @@ components:
             run:
               type: string
               description: 'The command to be executed, including any arguments using standard shell syntax. This field supports multiple commands piped together, as if they were executed under a bash -c context.'
-            envVars:
+            envVars: 
               type: array
               items:
                 type: string
@@ -2741,6 +2889,8 @@ components:
           description: 'List of Devices.'
           items:
             $ref: '#/components/schemas/Device'
+        summary:
+          $ref: '#/components/schemas/DevicesSummary'
       description: DeviceList is a list of Devices.
       required:
         - apiVersion
@@ -2895,10 +3045,14 @@ components:
       type: object
       required:
         - image
+        - imageDigest
       properties:
         image:
           type: string
           description: "Version of the OS image."
+        imageDigest:
+          type: string
+          description: "The digest of the OS image (e.g. sha256:a0...)"
     DeviceConfigStatus:
       type: object
       required:
@@ -3039,6 +3193,49 @@ components:
           description: 'approvedAt is the time at which the request was approved.'
       required:
         - approved
+    EnrollmentServiceAuth:
+      type: object
+      properties:
+        client-certificate-data:
+          type: string
+        client-key-data:
+          type: string
+      required:
+        - client-certificate-data
+        - client-key-data
+    EnrollmentServiceService:
+      type: object
+      properties:
+        certificate-authority-data:
+          type: string
+        server:
+          type: string
+      required:
+        - certificate-authority-data
+        - server
+    EnrollmentService:
+      type: object
+      properties:
+        authentication:
+          $ref: '#/components/schemas/EnrollmentServiceAuth'
+        service:
+          $ref: '#/components/schemas/EnrollmentServiceService'
+        enrollment-ui-endpoint:
+          type: string
+      required:
+        - authentication
+        - service
+        - enrollment-ui-endpoint
+    EnrollmentConfig:
+      type: object
+      properties:
+        enrollment-service:
+          $ref: '#/components/schemas/EnrollmentService'
+        grpc-management-endpoint:
+          type: string
+      required:
+        - enrollment-service
+        - grpc-management-endpoint
     EnrollmentRequest:
       type: object
       properties:
@@ -3095,7 +3292,7 @@ components:
         labels:
           type: object
           additionalProperties:
-            type: string
+            type: string 
           description: 'A set of labels that the service will apply to this device when its enrollment is approved'
       description: EnrollmentRequestSpec is a description of a EnrollmentRequest's target state.
     EnrollmentRequestStatus:
@@ -3274,6 +3471,10 @@ components:
                 type: string
         config:
           type: string
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/RenderedApplicationSpec'
         hooks:
           $ref: '#/components/schemas/DeviceHooksSpec'
         systemd:
@@ -3343,6 +3544,11 @@ components:
               propertyName: configType
         hooks:
           $ref: '#/components/schemas/DeviceHooksSpec'
+        applications:
+          type: array
+          description: List of applications.
+          items:
+            $ref: '#/components/schemas/ApplicationSpec'
         containers:
           type: object
           properties:
@@ -3383,21 +3589,34 @@ components:
       description: A summary of the devices in the fleet returned when fetching a single Fleet.
       required:
       - total
+      - applicationStatus
       - summaryStatus
       - updateStatus
       properties:
         total:
           type: integer
+          format: int64
           description: The total number of devices in the fleet.
-        summaryStatus:
+        applicationStatus:
           type: object
+          default: {}
           additionalProperties:
             type: integer
+            format: int64
+          description: A breakdown of the devices in the fleet by "application" status.
+        summaryStatus:
+          type: object
+          default: {}
+          additionalProperties:
+            type: integer
+            format: int64
           description: A breakdown of the devices in the fleet by "summary" status.
         updateStatus:
           type: object
+          default: {}
           additionalProperties:
             type: integer
+            format: int64
           description: A breakdown of the devices in the fleet by "updated" status.
     TemplateVersion:
       type: object
@@ -3733,3 +3952,4 @@ components:
       required:
         - conditions
       type: object
+      

--- a/demo/README.md
+++ b/demo/README.md
@@ -23,6 +23,9 @@ ansible-galaxy collection install . --force
 ansible-playbook demo/create.yml --extra-vars "flightctl_config_file='~/.flightctl/client.yaml'"
 ```
 
-The `--extra-vars` allows us to pass variables into the playbooks.  In this case the create playbook is dependent on the flightctl_config_file variable pointing towards the generated client.yaml used when deploying the local flightctl services.
+The `--extra-vars` allows us to pass variables into the playbooks.  In this case the create playbook is dependent on the flightctl_config_file variable pointing towards the generated client.yaml used when deploying the local flightctl services.  Default values for this are:
+
+- OSX: "~/Library/Application\ Support/flightctl/client.yaml"
+- Linux: "~/.flightctl/client.yaml"
 
 Note that the `create.yml` playbook makes assertations around when certain entities are being created - this results in situations where running the create playbook twice in a row will result in a failure.  Right now the `delete.yml` playbook should be run to clean up entities generated during the `create.yml` playbook and create can then be sucessfully run once more.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,28 @@
+# Demos
+
+This directory contains demo playbooks for creating and deleting various resources within the flightctl service.
+
+## Running demo playbooks with a locally running flightctl instance
+
+The following steps assume that you have a locally running flightctl cluster via the steps described in the [flightctl repo](https://github.com/flightctl/flightctl/blob/main/docs/user/getting-started.md) - e.g. `make deploy`.
+
+1.  Begin by creating a python virtual environment with the necessary dependencies.
+
+```
+python -m venv env
+source venv/bin/activate
+pip install -r requirements.txt
+```
+2.  Install the ansible collection locally.  The '--force' argument may not always be relevant but will make sure any local changes you make show in the installed collection.
+```
+ansible-galaxy collection install . --force
+```
+
+3.  Run a playbook.
+```
+ansible-playbook demo/create.yml --extra-vars "flightctl_config_file='~/.flightctl/client.yaml'"
+```
+
+The `--extra-vars` allows us to pass variables into the playbooks.  In this case the create playbook is dependent on the flightctl_config_file variable pointing towards the generated client.yaml used when deploying the local flightctl services.
+
+Note that the `create.yml` playbook makes assertations around when certain entities are being created - this results in situations where running the create playbook twice in a row will result in a failure.  Right now the `delete.yml` playbook should be run to clean up entities generated during the `create.yml` playbook and create can then be sucessfully run once more.

--- a/demo/create.yml
+++ b/demo/create.yml
@@ -1,11 +1,13 @@
 - name: Test Flight Control Collection to create resources
   hosts: localhost
+  vars: 
+    flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
 
   tasks:
     - name: Set default credentials
       ansible.builtin.set_fact:
         credential_defaults: &credential_defaults
-          flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
+          flightctl_config_file: "{{ flightctl_config_file }}"
 
     - name: Get all devices
       flightctl.edge.flightctl_info:

--- a/demo/create.yml
+++ b/demo/create.yml
@@ -1,7 +1,5 @@
 - name: Test Flight Control Collection to create resources
   hosts: localhost
-  vars: 
-    flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
 
   tasks:
     - name: Set default credentials

--- a/demo/delete.yml
+++ b/demo/delete.yml
@@ -1,13 +1,11 @@
 - name: Test Flight Control Collection to delete resources
   hosts: localhost
-  vars: 
-    flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
 
   tasks:
     - name: Set default credentials
       ansible.builtin.set_fact:
         credential_defaults: &credential_defaults
-          flightctl_config_file: "{{ flightctl_config_file }}"
+          flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
 
     - name: Delete devices
       flightctl.edge.flightctl:

--- a/demo/delete.yml
+++ b/demo/delete.yml
@@ -1,11 +1,13 @@
 - name: Test Flight Control Collection to delete resources
   hosts: localhost
+  vars: 
+    flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
 
   tasks:
     - name: Set default credentials
       ansible.builtin.set_fact:
         credential_defaults: &credential_defaults
-          flightctl_config_file: "~/Library/Application\ Support/flightctl/client.yaml"
+          flightctl_config_file: "{{ flightctl_config_file }}"
 
     - name: Delete devices
       flightctl.edge.flightctl:

--- a/demo/files/fleet.yml
+++ b/demo/files/fleet.yml
@@ -30,16 +30,9 @@ spec:
         - name: motd-update
           configType: InlineConfigProviderSpec
           inline:
-            ignition:
-              version: 3.4.0
-            storage:
-              files:
-                - contents:
-                    source: >-
-                      data:,This%20system%20is%20managed%20by%20flightctl.%0A
-                  mode: 422
-                  overwrite: true
-                  path: "/etc/motd"
+            - path: "/etc/motd"
+              content: "This system is managed by flightctl."
+              mode: 0644
       systemd:
         matchPatterns:
           - chronyd.service

--- a/plugins/module_utils/config_loader.py
+++ b/plugins/module_utils/config_loader.py
@@ -31,7 +31,6 @@ class ConfigLoader:
                     "properties": {
                         "token": {"type": "string"}  # token must be a string
                     },
-                    "required": ["token"],  # token field is required
                 },
                 "service": {
                     "type": "object",

--- a/plugins/module_utils/resources.py
+++ b/plugins/module_utils/resources.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from typing import Any, Dict, Iterable, List, Optional, Union, cast
+
+import yaml
+from ansible.module_utils.six import string_types
+
+
+class ResourceDefinition(Dict[str, Any]):
+    """
+    Representation of a resource definition.
+    """
+
+    @property
+    def kind(self) -> Optional[str]:
+        return self.get("kind")
+    
+    @property
+    def api_version(self) -> Optional[str]:
+        return self.get("apiVersion")
+    
+    @property
+    def name(self) -> Optional[str]:
+        metadata = self.get("metadata", {})
+        return metadata.get("name")
+    
+
+def from_yaml(definition: Union[str, List, Dict]) -> Iterable[Dict]:
+    """Load resource definitions from a yaml definition."""
+    definitions: List[Dict] = []
+    if isinstance(definition, string_types):
+        definitions += yaml.safe_load_all(definition)
+    elif isinstance(definition, list):
+        for item in definition:
+            if isinstance(item, string_types):
+                definitions += yaml.safe_load_all(item)
+            else:
+                definitions.append(item)
+    else:
+        definition = cast(Dict, definition)
+        definitions.append(definition)
+
+    return filter(None, definitions)
+
+
+def merge_params(definition: Dict[str, Any], params: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge module parameters with the resource definition.
+
+    Fields in the resource definition take precedence over module parameters.
+    """
+    definition.setdefault("kind", params.get("kind"))
+    definition.setdefault("apiVersion", params.get("api_version"))
+    metadata = definition.setdefault("metadata", {})
+    # The following should only be set if we have values for them
+    if params.get("name"):
+        metadata.setdefault("name", params.get("name"))
+    return definition
+
+
+def flatten_list_kind(definition: Dict[str, Any], params: Dict[str, Any]) -> List[Dict]:
+    """Replace *List kind with the items it contains.
+
+    This will take a definition for a *List resource and return a list of
+    definitions for the items contained within the List.
+    """
+    items = []
+    kind = cast(str, definition.get("kind"))[:-4]
+    api_version = definition.get("apiVersion")
+    for item in definition.get("items", []):
+        item.setdefault("kind", kind)
+        item.setdefault("apiVersion", api_version)
+        items.append(merge_params(item, params))
+    return items
+
+
+def create_definitions(params: Dict) -> List[ResourceDefinition]:
+    """Create a list of ResourceDefinitions from module inputs.
+
+    This will take the module's inputs and return a list of ResourceDefintion
+    objects. The resource definitions returned by this function should be as
+    complete a definition as we can create based on the input. Any *List kinds
+    will be removed and replaced by the resources contained in it.
+    """
+    if params.get("resource_definition"):
+        d = cast(Union[str, List, Dict], params.get("resource_definition"))
+        definitions = from_yaml(d)
+    else:
+        # We'll create an empty definition and let merge_params set values
+        # from the module parameters.
+        definitions = [{}]
+        
+    resource_definitions: List[Dict] = []
+    for definition in definitions:
+        merge_params(definition, params)
+        kind = cast(Optional[str], definition.get("kind"))
+        if kind and kind.endswith("List"):
+            resource_definitions += flatten_list_kind(definition, params)
+        else:
+            resource_definitions.append(definition)
+    return list(map(ResourceDefinition, resource_definitions))


### PR DESCRIPTION
Updates to ensure easy spin up and working demos with locally running flightctl services.   A couple things were out of date with the currently running apis so this should get us back to parity.

- Updates the openapi.yml schema to latest from the main repo
- Adds a variable to the create / delete demo playbooks for passing the flightctl config file.  The current value is hardcoded for what I believe is the OS X default location where the client.yml is generated, this allows for passing other values such as $HOME/.flightctl/client.yml where it is placed by default in Linux systems
- Fixes an outdated / mismatched fleet spec definition that fails when sent against the latest version of the flightctl api
- Removes the token field as being required.  This is due to flightctl being deployable locally with auth disabled.
- Adds back a file that was [removed previously](https://github.com/flightctl/flightctl-ansible/commit/4d47f626b4d666ad225ae8cd08e18be175a284ed#diff-5513526e7a92323b3f740abbfb66f48112d2115a10364572105a4c2ad05acbebL18) when I _think_ it was intended to be renamed.  Addresses an issue w/ a missing import in `runner.py`
- Adds a small readme for getting the demos up and running.  Eventually as this repo becomes more production ready I wonder if the demos should be moved to a separate repository (such as [flightctl-demos](https://github.com/flightctl/flightctl-demos) ?)