### PR TITLE
Allow the flightctl_config_file path to be set as an env variable

### DIFF
--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -47,6 +47,7 @@ options:
   flightctl_config_file:
     description:
     - Path to the config file.
+    - If value not set, will try environment variable C(FLIGHTCTL_CONFIG_FILE).
     type: path
     aliases: [ config_file ]
 """

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -44,7 +44,10 @@ class FlightctlModule(AnsibleModule):
             fallback=(env_fallback, ["FLIGHTCTL_TOKEN"]),
         ),
         flightctl_config_file=dict(
-            required=False, type="path", aliases=["config_file"]
+            required=False,
+            type="path",
+            aliases=["config_file"],
+            fallback=(env_fallback, ["FLIGHTCTL_CONFIG_FILE"]),
         ),
     )
     short_params: Dict[str, str] = {


### PR DESCRIPTION
Allow the flightctl_config_file path to be set as an env variable