### PR TITLE
kind can be either set using kind option or inside resource_definition

### DIFF
--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -399,13 +399,12 @@ class FlightctlAPIModule(FlightctlModule):
         return [response.json]
 
     def create(
-        self, params: Dict[str, Any], definition: Dict[str, Any]
+        self, definition: Dict[str, Any]
     ) -> Tuple[bool, Dict[str, Any]]:
         """
         Creates a new resource in the API.
 
         Args:
-            params (Dict[str, Any]): The resource parameters (kind, name, etc.).
             definition (Dict[str, Any]): The resource definition.
 
         Returns:
@@ -418,12 +417,12 @@ class FlightctlAPIModule(FlightctlModule):
             FlightctlException: If the creation fails.
         """
         changed: bool = False
-        response = self.post_endpoint(params["kind"], **definition)
+        response = self.post_endpoint(definition.get("kind"), **definition)
         if response.status == 201:
             changed |= True
         else:
             msg = (
-                f"Unable to create {params['kind']} {params['name']}: {response.status}"
+                f"Unable to create {definition.get('kind')} {definition.get('metadata', None).get('name', None)}: {response.status}"
             )
             raise FlightctlException(msg)
 

--- a/plugins/module_utils/runner.py
+++ b/plugins/module_utils/runner.py
@@ -170,7 +170,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
                 module.exit_json(**{"changed": True})
 
             try:
-                changed, result = module.create(module.params, definition)
+                changed, result = module.create(definition)
             except Exception as e:
                 raise FlightctlException(f"Failed to create resource: {e}") from e
 


### PR DESCRIPTION
This change will allow `kind` to be set using the `kind` or `resource_definition` option when a resource is created. `kind` will always be taken from the definition as it is passed to the API.

After this change, a resource (e.g., a device in this example) can be created also like:

```
    - name: Create a test device
      flightctl.edge.flightctl:
        <<: *credential_defaults
        resource_definition:
          apiVersion: v1alpha1
          kind: Device
          metadata:
            name: "device-ansible-example"
            labels:
              fleet: default
              novalue: ""
      register: _result
```