### PR TITLE
Modify the Info module to always return a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This Ansible Collection includes Ansible content to help automate the management
 
 This collection enables organizations to automate time-consuming, error-prone tasks, enhancing efficiency and reducing manual effort. By leveraging it, teams can quickly adapt to shifting conditions across diverse IT environments, improving both operational agility and resilience. Its primary goal is to streamline mission-critical workflows for better overall performance.
 
+More information about Flight Control can be found in the [main repo](https://github.com/flightctl/flightctl/).  The [user docs](https://github.com/flightctl/flightctl/blob/main/docs/user/README.md) in particular are helpful for understanding the concepts and capabilities of Flight Control.
+
 ## Requirements
 
 ### Ansible version compatibility
@@ -114,7 +116,38 @@ You can either call modules, rulebooks and playbooks by their Fully Qualified Co
   - name: Get all fleets
     flightctl.edge.flightctl_info:
       kind: Fleet
+
+  - name: Update the resource definition for a fleet
+    flightctl.edge.flightctl:
+      kind: Fleet
+      name: "asible-test-fleet"
+      resource_definition:
+        spec:
+          os:
+            image: quay.io/redhat/rhde:9.3
 ```
+
+## Testing
+
+There are unit, sanity, and integration tests configured to run for this repository.
+Currently only sanity and unit tests are run in CI via gihub workflows.
+
+### Unit Tests
+
+Run locally via `make test-unit`
+
+### Sanity Tests
+
+Run locally via `make test-sanity`
+
+### Integration Tests
+
+Integration tests are dependent on:
+- A flightctl instance the tests can hit
+  - Locally the easiest way is to run `make deploy` from the main flightctl repository
+- The flightctl_host var inside integration_config.yml set to the running flightctl api service
+
+Run locally via `make test-integration`
 
 ## License Information
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This Ansible Collection includes Ansible content to help automate the management
 
 This collection enables organizations to automate time-consuming, error-prone tasks, enhancing efficiency and reducing manual effort. By leveraging it, teams can quickly adapt to shifting conditions across diverse IT environments, improving both operational agility and resilience. Its primary goal is to streamline mission-critical workflows for better overall performance.
 
-More information about Flight Control can be found in the [main repo](https://github.com/flightctl/flightctl/).  The [user docs](https://github.com/flightctl/flightctl/blob/main/docs/user/README.md) in particular are helpful for understanding the concepts and capabilities of Flight Control.
-
 ## Requirements
 
 ### Ansible version compatibility
@@ -148,6 +146,19 @@ Integration tests are dependent on:
 - The flightctl_host var inside integration_config.yml set to the running flightctl api service
 
 Run locally via `make test-integration`
+
+## Support
+
+If you encounter issues or have questions, you can submit a support request through the following channels:
+ - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/flightctl/flightctl-ansible/issues).
+
+## Release notes
+
+See the [changelog](https://github.com/flightctl/flightctl-ansible/blob/main/CHANGELOG.md).
+
+## Related Information
+
+More information about Flight Control can be found in the [main repo](https://github.com/flightctl/flightctl). The [user docs](https://github.com/flightctl/flightctl/blob/main/docs/user/README.md) in particular are helpful for understanding the concepts and capabilities of Flight Control.
 
 ## License Information
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,6 +17,7 @@ readme: README.md
 # @nicks:irc/im.site#channel'
 authors:
 - Alina Buzachis <abuzachis@redhat.com>
+- Dakota Crowder <dcrowder@redhat.com>
 
 
 ### OPTIONAL but strongly recommended
@@ -50,10 +51,10 @@ dependencies: {}
 repository: github.com/flightctl/flightctl-ansible
 
 # The URL to any online docs
-documentation: http://docs.example.com
+documentation: https://github.com/flightctl/flightctl/blob/main/docs/user/README.md
 
 # The URL to the homepage of the collection/project
-homepage: http://example.com
+homepage: github.com/flightctl/flightctl-ansible
 
 # The URL to the collection issue tracker
 issues: github.com/flightctl/flightctl-ansible/issues

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -193,7 +193,7 @@ class FlightctlAPIModule(FlightctlModule):
             return ListResult(
                 data=response.items,
                 metadata=response.metadata,
-                summary=response.summary
+                summary=getattr(response, 'summary', None)
             )
 
     def create(

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-from typing import Any, Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 from .constants import API_MAPPING, ResourceType
 from .core import FlightctlModule
@@ -22,10 +23,43 @@ try:
     from flightctl.exceptions import ApiException, NotFoundException
     from flightctl.models.patch_request_inner import PatchRequestInner
     from flightctl.models.enrollment_request_approval import EnrollmentRequestApproval
+    from flightctl.models.list_meta import ListMeta
 except ImportError as imp_exc:
+    ListMeta = None
     CLIENT_IMPORT_ERROR = imp_exc
 else:
     CLIENT_IMPORT_ERROR = None
+
+
+class ResourceProtocol(Protocol):
+    def to_dict(self) -> Dict[str, Any]:
+        return {}
+
+
+class ListProtocol(Protocol):
+    items: List[ResourceProtocol]
+    metadata: ListMeta
+    summary: Optional[Any] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {}
+
+
+@dataclass
+class ListResult:
+    data: List[ResourceProtocol]
+    metadata: Optional[ListMeta] = None
+    summary: Optional[Any] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        res = dict(
+            data=[d.to_dict() for d in self.data],
+        )
+        if self.metadata:
+            res['metadata'] = self.metadata.to_dict()
+        if self.summary:
+            res['summary'] = self.summary.to_dict()
+        return res
 
 
 class FlightctlAPIModule(FlightctlModule):
@@ -75,7 +109,7 @@ class FlightctlAPIModule(FlightctlModule):
 
     def get(
         self, options: GetOptions,
-    ) -> Optional[Any]:
+    ) -> ResourceProtocol:
         """
         Makes an get query via the API.
 
@@ -107,7 +141,7 @@ class FlightctlAPIModule(FlightctlModule):
         except ApiException as e:
             raise FlightctlApiException(f"Unable to fetch {options.resource.value} - {options.name}: {e}")
 
-    def list(self, options: GetOptions) -> Any:
+    def list(self, options: GetOptions) -> ListProtocol:
         """
         Makes an list query via the API.
 
@@ -134,7 +168,7 @@ class FlightctlAPIModule(FlightctlModule):
 
     def get_one_or_many(
         self, options: GetOptions,
-    ) -> Any:
+    ) -> ListResult:
         """
         Retrieves one or many resources from the API.
 
@@ -152,17 +186,19 @@ class FlightctlAPIModule(FlightctlModule):
         if options.name:
             response = self.get(options)
             if not response:
-                return []
-            return response.to_dict()
+                return ListResult(data=[])
+            return ListResult(data=[response])
         else:
-            res = self.list(options)
-            if res:
-                return res.to_dict()
-            return {}
+            response = self.list(options)
+            return ListResult(
+                data=response.items,
+                metadata=response.metadata,
+                summary=response.summary
+            )
 
     def create(
         self, resource: ResourceType, definition: Dict[str, Any]
-    ) -> Any:
+    ) -> ResourceProtocol:
         """
         Creates a new resource in the API.
 
@@ -184,12 +220,12 @@ class FlightctlAPIModule(FlightctlModule):
 
         try:
             request_obj = api_type.model.from_dict(definition)
-            return create_call(request_obj).to_dict()
+            return create_call(request_obj)
         except ApiException as e:
             raise FlightctlApiException(f"Unable to create {resource.value}: {e}")
 
     def update(
-        self, resource: ResourceType, existing: Dict[str, Any], definition: Dict[str, Any]
+        self, resource: ResourceType, existing_obj: ResourceProtocol, definition: Dict[str, Any]
     ) -> Tuple[bool, Dict[str, Any]]:
         """
         Updates an existing resource.
@@ -212,6 +248,7 @@ class FlightctlAPIModule(FlightctlModule):
             FlightctlException: If the update fails or there are errors with the patch.
         """
         changed: bool = False
+        existing = existing_obj.to_dict()
         name = existing["metadata"]["name"]
 
         patch = get_patch(existing, definition)
@@ -227,16 +264,16 @@ class FlightctlAPIModule(FlightctlModule):
 
             try:
                 patch_params = [PatchRequestInner.from_dict(p) for p in patch]
-                response = patch_call(name, patch_params).to_dict()
+                response = patch_call(name, patch_params)
                 changed |= True
             except ApiException as e:
                 raise FlightctlApiException(f"Unable to create {resource.value}: {e}")
 
-        return changed, (response if diffs else existing)
+        return changed, (response if diffs else existing_obj)
 
     def replace(
             self, resource: ResourceType, definition: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    ) -> ResourceProtocol:
         """
         Replaces an existing resource.
 
@@ -256,11 +293,11 @@ class FlightctlAPIModule(FlightctlModule):
 
         try:
             request_obj = api_type.model.from_dict(definition)
-            return replace_call(name, request_obj).to_dict()
+            return replace_call(name, request_obj)
         except ApiException as e:
             raise FlightctlApiException(f"Unable to replace {resource.value}: {e}")
 
-    def delete(self, resource: ResourceType, name: str, fleet_name: str) -> Optional[Any]:
+    def delete(self, resource: ResourceType, name: str, fleet_name: str) -> Optional[ResourceProtocol]:
         """
         Deletes resources from the API.
 
@@ -296,7 +333,7 @@ class FlightctlAPIModule(FlightctlModule):
             except ApiException as e:
                 raise FlightctlApiException(f"Unable to delete {resource.value} - {name}: {e}")
 
-        return response.to_dict()
+        return response
 
     def approve(self, input: ApprovalOptions) -> None:
         """

--- a/plugins/module_utils/runner.py
+++ b/plugins/module_utils/runner.py
@@ -173,7 +173,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
         raise FlightctlException(f"Failed to get resource: {e}") from e
 
     if state == "absent":
-        if existing_result:
+        if existing_result.data:
             if module.check_mode:
                 module.exit_json(**{"changed": True})
 
@@ -184,7 +184,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
                 raise FlightctlException(f"Failed to delete resource: {e}") from e
 
     elif state == "present":
-        if existing_result:
+        if existing_result.data:
             # Update resource
             if module.check_mode:
                 module.exit_json(**{"changed": True})
@@ -194,7 +194,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
                     result = module.replace(resource, definition)
                     changed |= True
                 else:
-                    changed, result = module.update(resource, existing_result, definition)
+                    changed, result = module.update(resource, existing_result.data[0], definition)
             except Exception as e:
                 raise FlightctlException(f"Failed to update resource: {e}") from e
         else:
@@ -208,7 +208,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
             except Exception as e:
                 raise FlightctlException(f"Failed to create resource: {e}") from e
 
-    return changed, result
+    return changed, result.to_dict()
 
 
 def perform_approval(module: FlightctlAPIModule) -> None:

--- a/plugins/modules/flightctl_enrollment_config_info.py
+++ b/plugins/modules/flightctl_enrollment_config_info.py
@@ -109,11 +109,11 @@ def main():
     )
 
     try:
-        result = module.get_one_or_many(options)
+        result = module.get(options)
     except FlightctlException as e:
         module.fail_json(msg=f"Failed to get resource: {e}")
 
-    module.exit_json(result=result)
+    module.exit_json(result=result.to_dict())
 
 
 if __name__ == "__main__":

--- a/plugins/modules/flightctl_info.py
+++ b/plugins/modules/flightctl_info.py
@@ -157,7 +157,7 @@ result:
       type: dict
       returned: When C(name) is not used and a list of objects is fetched
       contains:
-        continue_token:
+        continue:
           description: An opaque token used to issue another request to the endpoint that served a list to retrieve the next set of available objects.
           returned: When the total number of items queried is greater than C(limit) or the default limit.
           type: str
@@ -226,7 +226,7 @@ def main():
     except FlightctlException as e:
         module.fail_json(msg=f"Failed to get resource: {e}")
 
-    module.exit_json(result=result)
+    module.exit_json(result=result.to_dict())
 
 
 if __name__ == "__main__":

--- a/tests/integration/targets/flightctl/tasks/delete-template-versions.yml
+++ b/tests/integration/targets/flightctl/tasks/delete-template-versions.yml
@@ -54,7 +54,7 @@
     ansible.builtin.assert:
       that:
         - template_version_result is success
-        - template_version_result.result['items'] | length == 3
+        - template_version_result.result.data | length == 3
 
   - name: Delete a template version by name
     flightctl.edge.flightctl:
@@ -62,7 +62,7 @@
       flightctl_validate_certs: false
       kind: TemplateVersion
       fleet_name: "{{ fleet_name }}"
-      name: "{{ template_version_result.result['items'][0]['metadata']['name'] }}"
+      name: "{{ template_version_result.result.data[0]['metadata']['name'] }}"
       state: absent
     register: delete_single_template_version_result
 
@@ -84,7 +84,7 @@
     ansible.builtin.assert:
       that:
         - template_version_result is success
-        - template_version_result.result["items"] | length == 2
+        - template_version_result.result.data | length == 2
 
   - name: Delete all template versions owned by a fleet
     flightctl.edge.flightctl:
@@ -113,7 +113,7 @@
     ansible.builtin.assert:
       that:
         - template_version_result is success
-        - template_version_result.result["items"] | length == 0
+        - template_version_result.result.data | length == 0
   always:
     - flightctl.edge.flightctl:
         flightctl_host: "{{ flightctl_host }}"

--- a/tests/integration/targets/flightctl/tasks/update-device.yml
+++ b/tests/integration/targets/flightctl/tasks/update-device.yml
@@ -39,8 +39,8 @@
     ansible.builtin.assert:
       that:
         - device_result is success
-        - device_result.result.spec.os.image == "quay.io/redhat/rhde:9.3"
-        - device_result.result.spec.systemd.matchPatterns[0] == "chronyd.service"
+        - device_result.result.data[0].spec.os.image == "quay.io/redhat/rhde:9.3"
+        - device_result.result.data[0].spec.systemd.matchPatterns[0] == "chronyd.service"
 
   - name: Update the test device with force_update
     flightctl.edge.flightctl:
@@ -66,8 +66,8 @@
     ansible.builtin.assert:
       that:
         - device_result is success
-        - device_result.result.spec.os.image == "quay.io/redhat/rhde:9.4"
-        - "'systemd' not in device_result.result.spec"
+        - device_result.result.data[0].spec.os.image == "quay.io/redhat/rhde:9.4"
+        - "'systemd' not in device_result.result.data[0].spec"
 
   always:
     - name: Delete test device

--- a/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-approval.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-approval.yml
@@ -44,8 +44,8 @@
     ansible.builtin.assert:
       that:
         - csr_result is success
-        - csr_result.result.status.conditions[0].type == "Approved"
-        - csr_result.result.status.conditions[0].status == "True"
+        - csr_result.result.data[0].status.conditions[0].type == "Approved"
+        - csr_result.result.data[0].status.conditions[0].status == "True"
 
   - name: Try to approve the csr again (idempotency)
     flightctl.edge.flightctl_certificate:

--- a/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-denial.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-denial.yml
@@ -44,9 +44,9 @@
     ansible.builtin.assert:
       that:
         - csr_result is success
-        - csr_result.result.status.conditions[0].type == "Approved"
-        - csr_result.result.status.conditions[0].message == "Denied"
-        - csr_result.result.status.conditions[0].status == "False"
+        - csr_result.result.data[0].status.conditions[0].type == "Approved"
+        - csr_result.result.data[0].status.conditions[0].message == "Denied"
+        - csr_result.result.data[0].status.conditions[0].status == "False"
 
   - name: Try to approve the csr again (idempotency)
     flightctl.edge.flightctl_certificate:

--- a/tests/integration/targets/flightctl_certificate/tasks/enrollment-approval.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/enrollment-approval.yml
@@ -46,7 +46,7 @@
     ansible.builtin.assert:
       that:
         - check_result is success
-        - check_result.result.status.get('approval', None) == None
+        - check_result.result.data[0].status.get('approval', None) == None
 
   - name: Approve the enrollment request
     flightctl.edge.flightctl_certificate:
@@ -77,9 +77,9 @@
     ansible.builtin.assert:
       that:
         - enrollment_result is success
-        - enrollment_result.result.status.approval.approved == True
-        - enrollment_result.result.status.approval.approvedBy == "ansible-integration-testing"
-        - enrollment_result.result.status.approval.labels['testing_label'] == "is_set_during_testing"
+        - enrollment_result.result.data[0].status.approval.approved == True
+        - enrollment_result.result.data[0].status.approval.approvedBy == "ansible-integration-testing"
+        - enrollment_result.result.data[0].status.approval.labels['testing_label'] == "is_set_during_testing"
 
   - name: Try to approve the enrollment request again (idempotency)
     flightctl.edge.flightctl_certificate:

--- a/tests/integration/targets/flightctl_certificate/tasks/enrollment-denial.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/enrollment-denial.yml
@@ -46,7 +46,7 @@
     ansible.builtin.assert:
       that:
         - check_result is success
-        - check_result.result.status.get('approval', None) == None
+        - check_result.result.data[0].status.get('approval', None) == None
 
   - name: Deny the enrollment request
     flightctl.edge.flightctl_certificate:
@@ -77,7 +77,7 @@
     ansible.builtin.assert:
       that:
         - enrollment_result is success
-        - check_result.result.status.get('approval', None) == None
+        - check_result.result.data[0].status.get('approval', None) == None
 
   always:
     - name: Delete enrollment request

--- a/tests/integration/targets/flightctl_info/tasks/devices.yml
+++ b/tests/integration/targets/flightctl_info/tasks/devices.yml
@@ -45,7 +45,7 @@
     ansible.builtin.assert:
       that:
         - device_result is success
-        - device_result.result.metadata.name == "ansible-integration-test-device"
+        - device_result.result.data[0].metadata.name == "ansible-integration-test-device"
 
   - name: Get rendered spec for the test device
     flightctl.edge.flightctl_info:
@@ -60,7 +60,7 @@
     ansible.builtin.assert:
       that:
         - rendered_result is success
-        - rendered_result.result.os.image == "quay.io/redhat/rhde:9.2"
+        - rendered_result.result.data[0].os.image == "quay.io/redhat/rhde:9.2"
 
   - name: Create a test device with a label
     flightctl.edge.flightctl:
@@ -98,9 +98,9 @@
     ansible.builtin.assert:
       that:
         - device_with_label_result is success
-        - device_with_label_result.result["items"] | length == 2
-        - device_with_label_result.result["items"][0].metadata.name is match("ansible-integration-test-device-label-*")
-        - device_with_label_result.result["items"][1].metadata.name is match("ansible-integration-test-device-label-*")
+        - device_with_label_result.result.data | length == 2
+        - device_with_label_result.result.data[0].metadata.name is match("ansible-integration-test-device-label-*")
+        - device_with_label_result.result.data[1].metadata.name is match("ansible-integration-test-device-label-*")
 
   - name: Query for all devices by owner
     flightctl.edge.flightctl_info:
@@ -114,8 +114,8 @@
     ansible.builtin.assert:
       that:
         - device_with_owner_result is success
-        - device_with_owner_result.result["items"] | length == 1
-        - device_with_owner_result.result["items"][0].metadata.name == "ansible-integration-test-device"
+        - device_with_owner_result.result.data | length == 1
+        - device_with_owner_result.result.data[0].metadata.name == "ansible-integration-test-device"
 
   - name: Query for all devices
     flightctl.edge.flightctl_info:
@@ -128,7 +128,7 @@
     ansible.builtin.assert:
       that:
         - all_devices_result is success
-        - all_devices_result.result["items"] | length == 3
+        - all_devices_result.result.data | length == 3
 
   - name: Query for all devices with summary_only
     flightctl.edge.flightctl_info:
@@ -142,8 +142,8 @@
     ansible.builtin.assert:
       that:
         - summary_only_result is success
-        - summary_only_result.result["items"] | length == 0
-        - summary_only_result.result["summary"]["total"] == 3
+        - summary_only_result.result.data | length == 0
+        - summary_only_result.result.summary.total == 3
 
   - name: Query for all devices with a limit
     flightctl.edge.flightctl_info:
@@ -157,7 +157,7 @@
     ansible.builtin.assert:
       that:
         - limit_result is success
-        - limit_result.result["items"] | length == 2
+        - limit_result.result.data | length == 2
 
   - name: Use the continue token to query for remaining devices
     flightctl.edge.flightctl_info:
@@ -165,7 +165,7 @@
       flightctl_validate_certs: false
       kind: Device
       limit: 2
-      continue_token: "{{ limit_result.result['metadata']['continue'] }}"
+      continue_token: "{{ limit_result.result.metadata.continue }}"
     register: second_limit_result
 
   - name: Assert that the limited info was fetched
@@ -185,7 +185,7 @@
     ansible.builtin.assert:
       that:
         - status_filter_result is success
-        - status_filter_result.result["items"]| length == 0
+        - status_filter_result.result.data | length == 0
 
   - name: Query for devices with a filter selector
     flightctl.edge.flightctl_info:
@@ -199,7 +199,7 @@
     ansible.builtin.assert:
       that:
         - field_selector_result is success
-        - field_selector_result.result["items"] | length == 2
+        - field_selector_result.result.data | length == 2
 
   always:
     - name: Delete test devices
@@ -207,7 +207,6 @@
         flightctl_host: "{{ flightctl_host }}"
         flightctl_validate_certs: false
         kind: Device
-        name: "{{ deivce_name }}"
         state: absent
 
     - name: Delete test fleet

--- a/tests/integration/targets/flightctl_info/tasks/fleets.yml
+++ b/tests/integration/targets/flightctl_info/tasks/fleets.yml
@@ -48,7 +48,7 @@
     ansible.builtin.assert:
       that:
         - fleet_result is success
-        - fleet_result.result.status.devicesSummary.total == 3
+        - fleet_result.result.data[0].status.devicesSummary.total == 3
 
   always:
   - name: Delete test devices

--- a/tests/integration/targets/flightctl_info/tasks/repository.yml
+++ b/tests/integration/targets/flightctl_info/tasks/repository.yml
@@ -26,7 +26,7 @@
     ansible.builtin.assert:
       that:
         - repo_result is success
-        - repo_result.result.metadata.name == "ansible-integration-test-repository"
+        - repo_result.result.data[0].metadata.name == "ansible-integration-test-repository"
 
   always:
     - name: Delete test repo

--- a/tests/integration/targets/flightctl_info/tasks/resource-sync.yml
+++ b/tests/integration/targets/flightctl_info/tasks/resource-sync.yml
@@ -27,7 +27,7 @@
     ansible.builtin.assert:
       that:
         - resource_sync_result is success
-        - resource_sync_result.result.metadata.name == "ansible-integration-test-resource-sync"
+        - resource_sync_result.result.data[0].metadata.name == "ansible-integration-test-resource-sync"
 
   always:
     - name: Delete test resource sync


### PR DESCRIPTION
Previously the response type for the info module was polymorphic and didn't match the documentation.  This changes the behavior so the result is always a list (even by quering via the `name` identifier).  This seems to be consistent with some other collections I was looking at like [aws lambda_info](https://docs.ansible.com/ansible/latest/collections/amazon/aws/lambda_info_module.html#ansible-collections-amazon-aws-lambda-info-module) and provides a consistent experience when using the module.

Some ancillary changes:
- Modified  `items` in the info response value to be `data` due to items being a reserved word in in python and having to do things like `result['items']` rather than `result.items` as it is a [method on dict types](https://www.w3schools.com/python/ref_dictionary_items.asp) 
- Added a couple small README sections / updated doc links
- Refactored a bit of the api module so we try to pass around actual objects rather than dicts a bit more as well as add some `Protocol` classes for broadly representing some of the shared types we get back from the api