### PR TITLE
Add integration tests to workflows

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,26 +26,33 @@ jobs:
         with:
           repository: 'flightctl/flightctl'
           ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
-          path: flightctl
 
-      # - name: Setup dependencies for flightctl
-      #   uses: ./flightctl/.github/actions/setup-dependencies
-      #   with:
-      #     setup_podman4: yes
+      - name: Setup dependencies for flightctl
+        uses: ./flightctl/.github/actions/setup-dependencies
+        with:
+          setup_podman4: yes
 
       - name: Start flightctl services
-        working-directory: ./flightctl
-        run: make deploy-quadlets
+        working-directory: flightctl
+        run: make deploy
+
+      - name: Checkout collection
+        uses: actions/checkout@v4
+        with:
+          path: collection
 
       - name: Write server config to integration_config file
         run: |
           service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
-          echo "flightctl_host: $service_addr" > tests/integration/integration_config.yml
+          echo "flightctl_host: $service_addr" > collection/tests/integration/integration_config.yml
 
       - name: Perform integration testing
-        uses: ansible-community/ansible-test-gh-action@release/v1
-        with:
-          ansible-core-version: ${{ matrix.versions.ansible }}
-          origin-python-version: ${{ matrix.versions.python }}
-          target-python-version: ${{ matrix.versions.python }}
-          testing-type: integration
+        run: echo "This is where we would run our integration tests"
+
+      # - name: Perform integration testing
+      #   uses: ansible-community/ansible-test-gh-action@release/v1
+      #   with:
+      #     ansible-core-version: ${{ matrix.versions.ansible }}
+      #     origin-python-version: ${{ matrix.versions.python }}
+      #     target-python-version: ${{ matrix.versions.python }}
+      #     testing-type: integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,6 +38,7 @@ jobs:
       # TODO delete me
       - name: Fill fake config file
         run: |
+          mkdir ~/.config/flightctl
           echo "server: https://api.192.168.86.27.nip.io:3443" > ~/.config/flightctl/client.yaml
 
       - name: Checkout collection

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,25 +21,19 @@ jobs:
           - ansible: stable-2.16
             python: "3.10"
     steps:
-      # - name: Checkout flightctl
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: 'flightctl/flightctl'
-      #     ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
+      - name: Checkout flightctl
+        uses: actions/checkout@v4
+        with:
+          repository: 'flightctl/flightctl'
+          ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
 
-      # - name: Setup dependencies for flightctl
-      #   uses: ./.github/actions/setup-dependencies
-      #   with:
-      #     setup_podman4: yes
+      - name: Setup dependencies for flightctl
+        uses: ./.github/actions/setup-dependencies
+        with:
+          setup_podman4: yes
 
-      # - name: Start flightctl services
-      #   run: make deploy
-
-      # TODO delete me
-      - name: Fill fake config file
-        run: |
-          mkdir ~/.config/flightctl
-          echo "server: https://api.192.168.86.27.nip.io:3443" > ~/.config/flightctl/client.yaml
+      - name: Start flightctl services
+        run: make deploy
 
       - name: Checkout collection
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,50 @@
+---
+name: Integration tests
+
+# TODO modify to only run on PRs to main
+on: push
+# on:
+#   pull_request:
+#     branches:
+#       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        versions:
+          - ansible: stable-2.16
+            python: "3.10"
+    steps:
+      - name: Checkout flightctl
+        uses: actions/checkout@v4
+        with:
+          repository: 'flightctl/flightctl'
+          ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
+          path: flightctl
+
+      - name: Setup dependencies for flightctl
+        uses: ./flightctl/.github/actions/setup-dependencies
+        with:
+          setup_podman4: yes
+
+      - name: Start flightctl services
+        run: (cd ./flightctl && make deploy)
+
+      - name: Write server config to integration_config file
+        run: |
+          service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
+          echo "flightctl_host: $service_addr" > tests/integration/integration_config.yml
+
+      - name: Perform integration testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: ${{ matrix.versions.ansible }}
+          origin-python-version: ${{ matrix.versions.python }}
+          target-python-version: ${{ matrix.versions.python }}
+          testing-type: integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
 
       - name: Setup dependencies for flightctl
-        uses: .github/actions/setup-dependencies
+        uses: ./.github/actions/setup-dependencies
         with:
           setup_podman4: yes
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,37 +21,35 @@ jobs:
           - ansible: stable-2.16
             python: "3.10"
     steps:
-      - name: Checkout flightctl
-        uses: actions/checkout@v4
-        with:
-          repository: 'flightctl/flightctl'
-          ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
+      # - name: Checkout flightctl
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: 'flightctl/flightctl'
+      #     ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
 
-      - name: Setup dependencies for flightctl
-        uses: ./.github/actions/setup-dependencies
-        with:
-          setup_podman4: yes
+      # - name: Setup dependencies for flightctl
+      #   uses: ./.github/actions/setup-dependencies
+      #   with:
+      #     setup_podman4: yes
 
-      - name: Start flightctl services
-        run: make deploy
+      # - name: Start flightctl services
+      #   run: make deploy
 
       - name: Checkout collection
         uses: actions/checkout@v4
         with:
           path: collection
 
-      - name: Write server config to integration_config file
-        run: |
-          service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
-          echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
+      # - name: Write server config to integration_config file
+      #   run: |
+      #     service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
+      #     echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
 
       - name: Perform integration testing
-        run: echo "This is where we would run our integration tests"
-
-      # - name: Perform integration testing
-      #   uses: ansible-community/ansible-test-gh-action@release/v1
-      #   with:
-      #     ansible-core-version: ${{ matrix.versions.ansible }}
-      #     origin-python-version: ${{ matrix.versions.python }}
-      #     target-python-version: ${{ matrix.versions.python }}
-      #     testing-type: integration
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: ${{ matrix.versions.ansible }}
+          origin-python-version: ${{ matrix.versions.python }}
+          target-python-version: ${{ matrix.versions.python }}
+          testing-type: integration
+          collection-src-directory: ./collection

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,20 +35,19 @@ jobs:
       # - name: Start flightctl services
       #   run: make deploy
 
+      # TODO delete me
+      - name: Fill fake config file
+        run: |
+          echo "server: https://api.192.168.86.27.nip.io:3443" > ~/.config/flightctl/client.yaml
+
       - name: Checkout collection
         uses: actions/checkout@v4
         with:
           path: collection
 
-      # - name: Write server config to integration_config file
-      #   run: |
-      #     service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
-      #     echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
-
-      - name: Write server config to integration_config file
-        run: |
-          service_addr=https://api.flightctl.192.168.86.27.nip.io:3443
-          echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
+      - name: Write integration config
+        run: make write-integration-config
+        working-directory: ./collection
 
       - name: Perform integration testing
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,7 +33,6 @@ jobs:
           setup_podman4: yes
 
       - name: Start flightctl services
-        working-directory: flightctl
         run: make deploy
 
       - name: Checkout collection
@@ -44,7 +43,7 @@ jobs:
       - name: Write server config to integration_config file
         run: |
           service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
-          echo "flightctl_host: $service_addr" > collection/tests/integration/integration_config.yml
+          echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
 
       - name: Perform integration testing
         run: echo "This is where we would run our integration tests"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'flightctl/flightctl'
+          # This ref is an arbitrary value from a recent commit relative to workflow being written
+          # Once we begin to pin the collection against specific flightctl versions this should be updated
+          # to reference a specific release
           ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
 
       - name: Setup dependencies for flightctl

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
 
       - name: Setup dependencies for flightctl
-        uses: ./flightctl/.github/actions/setup-dependencies
+        uses: .github/actions/setup-dependencies
         with:
           setup_podman4: yes
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,12 +1,10 @@
 ---
 name: Integration tests
 
-# TODO modify to only run on PRs to main
-on: push
-# on:
-#   pull_request:
-#     branches:
-#       - main
+on:
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,13 +28,14 @@ jobs:
           ref: 'acfa41af729145511d2423ca8cd97aaa92aadd37'
           path: flightctl
 
-      - name: Setup dependencies for flightctl
-        uses: ./flightctl/.github/actions/setup-dependencies
-        with:
-          setup_podman4: yes
+      # - name: Setup dependencies for flightctl
+      #   uses: ./flightctl/.github/actions/setup-dependencies
+      #   with:
+      #     setup_podman4: yes
 
       - name: Start flightctl services
-        run: (cd ./flightctl && make deploy)
+        working-directory: ./flightctl
+        run: make deploy-quadlets
 
       - name: Write server config to integration_config file
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,6 +45,11 @@ jobs:
       #     service_addr=$(cat ~/.config/flightctl/client.yaml | grep server | awk '{print $2}')
       #     echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
 
+      - name: Write server config to integration_config file
+        run: |
+          service_addr=https://api.flightctl.192.168.86.27.nip.io:3443
+          echo "flightctl_host: $service_addr" > ./collection/tests/integration/integration_config.yml
+
       - name: Perform integration testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ test-unit:
 	ansible-test units --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
 
 test-integration:
-	ansible-test integration --diff --no-temp-workdir --color --python $(PYTHON_VERSION) -v $(?TEST_ARGS)
+	ansible-test integration --docker --diff --color --python $(PYTHON_VERSION) -v $(?TEST_ARGS)
 
 test-sanity:
 	ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
+
+write-integration-config:
+	@service_addr="$(shell cat ~/.config/flightctl/client.yaml | grep server | awk '{print $$2}')"; \
+    echo "flightctl_host: $$service_addr" > ./tests/integration/integration_config.yml

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`
 
-test-unit:
+unit-test:
 	ansible-test units --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
 
-test-integration:
+integration-test: write-integration-config
 	ansible-test integration --docker --diff --color --python $(PYTHON_VERSION) -v $(?TEST_ARGS)
 
-test-sanity:
+sanity-test:
 	ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
 
 write-integration-config:

--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ You can either call modules, rulebooks and playbooks by their Fully Qualified Co
 
 ## Testing
 
-There are unit, sanity, and integration tests configured to run for this repository.
-Currently only sanity and unit tests are run in CI via gihub workflows.
+There are unit, sanity, and integration tests configured to run for this repository.  Tests are configured to run via github actions on pull requests and can also be run locally.
+
+`ansible-test` is used to run each of the test types.  For `ansible-test` to properly work the collection must be present in the following directory structure on your local machine:
+
+{...}/ansible_collections/flightctl/edge/{code_from_this_repo}
 
 ### Unit Tests
 
@@ -142,10 +145,12 @@ Run locally via `make test-sanity`
 
 Integration tests are dependent on:
 - A flightctl instance the tests can hit
-  - Locally the easiest way is to run `make deploy` from the main flightctl repository
 - The flightctl_host var inside integration_config.yml set to the running flightctl api service
 
-Run locally via `make test-integration`
+The easiest way to run tests locally is to:
+- Run `make deploy` from the main flightctl repository
+- Run `make write-integration-config` from this repository to create the proper integration config from your running services
+- Run locally via `make test-integration`
 
 ## Support
 

--- a/plugins/modules/flightctl.py
+++ b/plugins/modules/flightctl.py
@@ -54,6 +54,7 @@ notes:
   - For resources other than O(kind=Device), O(resource_definition) must be specified when creating or
     updating a resource.
 requirements:
+  - jsonpatch
   - jsonschema
   - PyYAML
   - "flightctl (git+https://github.com/flightctl/flightctl-python-client.git)"

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,4 @@
+jsonschema
+jsonpatch
+openapi_schema_validator
+git+https://github.com/flightctl/flightctl-python-client.git

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,4 @@
+jsonpatch
 jsonschema
 openapi_schema_validator
 pytest


### PR DESCRIPTION
Makes the integration tests run via adding a gh workflow.

See the run for this PR [here](https://github.com/flightctl/flightctl-ansible/actions/runs/12146044622/job/33869040913?pr=14)

The way the tests are run is by checking out the flightctl repository, setting up dependencies, and then running a `make deploy` to get the services spun up.  This is a bit heavy handed (we are installing more dependencies than we need) and could be streamlined in the future but is the easiest way to get up and running.

Notes:
- A make utility helper has been added to update the config file the integration tests use to point to the flightctl api service by looking up the service address from the flightctl yaml config.  Ansbile integration tests don't have a great way to pass along config to tests dynamically so writing to this file was the easiest way for now
- Modified the integration tests to run locally in containers which is recommended and how the sanity/unit tests were already configured
