### PR TITLE
Typo in the demo readme.md

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -9,7 +9,7 @@ The following steps assume that you have a locally running flightctl cluster via
 1.  Begin by creating a python virtual environment with the necessary dependencies.
 
 ```
-python -m venv env
+python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README to reflect the renaming of the Python virtual environment from `env` to `venv` for local setup instructions. All other instructions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->