### PR TITLE
Implement auth using bearer tokens and basic auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,7 @@ sanity-test:
 	ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
 
 write-integration-config:
-	@service_addr="$(shell cat ~/.config/flightctl/client.yaml | grep server | awk '{print $$2}')"; \
-    echo "flightctl_host: $$service_addr" > ./tests/integration/integration_config.yml
+	@token="$(shell grep 'token:' ~/.config/flightctl/client.yaml | awk '{print $$2}')"; \
+	service_addr="$(shell grep 'server:' ~/.config/flightctl/client.yaml | awk '{print $$2}')"; \
+	echo "flightctl_token: $$token" > ./tests/integration/integration_config.yml; \
+	echo "flightctl_host: $$service_addr" >> ./tests/integration/integration_config.yml;

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -15,11 +15,14 @@ options:
     description:
     - Username for your Flight Control service.
     - If value not set, will try environment variable C(FLIGHTCTL_USERNAME)
+    - Please note that this only works with proxies configured to use HTTP Basic Auth.
     type: str
   flightctl_password:
     description:
     - Password for your Flight Control service.
     - If value not set, will try environment variable C(FLIGHTCTL_PASSWORD)
+    - Please read the description of the C(flightctl_username) option for a discussion of
+      when this option is applicable.
     type: str
   flightctl_token:
     description:

--- a/plugins/module_utils/runner.py
+++ b/plugins/module_utils/runner.py
@@ -8,20 +8,6 @@ __metaclass__ = type
 
 from typing import Any, Dict, List, Tuple
 
-try:
-    import yaml
-except ImportError as imp_exc:
-    PYYAML_IMPORT_ERROR = imp_exc
-else:
-    PYYAML_IMPORT_ERROR = None
-
-try:
-    from openapi_schema_validator import OAS30Validator
-except ImportError as imp_exc:
-    OPENAPI_SCHEMA_IMPORT_ERROR = imp_exc
-else:
-    OPENAPI_SCHEMA_IMPORT_ERROR = None
-
 from .api_module import FlightctlAPIModule
 from .constants import ResourceType
 from .exceptions import FlightctlException, ValidationException
@@ -35,52 +21,6 @@ except ImportError as imp_exc:
     CLIENT_IMPORT_ERROR = imp_exc
 else:
     CLIENT_IMPORT_ERROR = None
-
-
-def load_schema(file_path: str) -> Dict[str, Any]:
-    """
-    Loads an OpenAPI schema from a YAML file.
-
-    Args:
-        file_path (str): The path to the schema YAML file.
-
-    Returns:
-        Dict[str, Any]: The loaded schema as a dictionary.
-    """
-    if PYYAML_IMPORT_ERROR:
-        raise PYYAML_IMPORT_ERROR
-    with open(file_path, "r") as file:
-        schema = yaml.safe_load(file)
-    return schema
-
-
-def validate(definition: Dict[str, Any]) -> None:
-    """
-    Validates a resource definition against an OpenAPI schema.
-
-    Args:
-        definition (Dict[str, Any]): The resource definition to validate.
-
-    Raises:
-        ValueError: If the resource kind is not found in the schema.
-        ValidationException: If the validation fails.
-    """
-    if OPENAPI_SCHEMA_IMPORT_ERROR:
-        raise OPENAPI_SCHEMA_IMPORT_ERROR
-
-    kind = definition["kind"]
-    openapi_schema = load_schema("../../api/v1alpha1/openapi.yml")
-    components = openapi_schema.get("components", {}).get("schemas", {})
-    if kind not in components:
-        raise ValueError(f"Component {kind} not found in the schema")
-
-    component_schema = components[kind]
-    validator = OAS30Validator(openapi_schema)
-
-    try:
-        validator.validate(definition, component_schema)
-    except Exception as e:
-        raise ValidationException(f"Validation error: {e}") from e
 
 
 def get_definitions(params: Dict[str, Any]) -> List:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ansible-core>=2.15
 pyyaml>=6.0.1
-openapi_schema_validator
 jsonpatch
 jsonschema
 git+https://github.com/flightctl/flightctl-python-client.git

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,3 @@
 jsonschema
 jsonpatch
-openapi_schema_validator
 git+https://github.com/flightctl/flightctl-python-client.git

--- a/tests/integration/targets/flightctl/tasks/update-device.yml
+++ b/tests/integration/targets/flightctl/tasks/update-device.yml
@@ -1,11 +1,14 @@
 - name: Test Update Device
   vars:
     deivce_name: ansible-integration-test-device
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a test device
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
       resource_definition:
@@ -18,8 +21,7 @@
 
   - name: Update the test device
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
       resource_definition:
@@ -29,8 +31,7 @@
 
   - name: Get test device
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
     register: device_result
@@ -44,8 +45,7 @@
 
   - name: Update the test device with force_update
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
       force_update: True
@@ -56,8 +56,7 @@
 
   - name: Get test device
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
     register: device_result
@@ -72,8 +71,7 @@
   always:
     - name: Delete test device
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: Device
         name: "{{ deivce_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-approval.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-approval.yml
@@ -2,11 +2,14 @@
 - name: Test approve certificate signing request
   vars:
     csr_name: ansible-integration-test-approval-csr
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a csr
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       api_version: v1alpha1
@@ -18,8 +21,7 @@
 
   - name: Approve the csr
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       approved: true
@@ -34,8 +36,7 @@
 
   - name: Get the csr
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
     register: csr_result
@@ -49,8 +50,7 @@
 
   - name: Try to approve the csr again (idempotency)
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       approved: true
@@ -65,8 +65,7 @@
   always:
     - name: Delete csr
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: CertificateSigningRequest
         name: "{{ csr_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-denial.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/certificate-signing-denial.yml
@@ -2,11 +2,14 @@
 - name: Test approve certificate signing request
   vars:
     csr_name: ansible-integration-test-denial-csr
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a csr
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       api_version: v1alpha1
@@ -18,8 +21,7 @@
 
   - name: Deny the csr
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       approved: false
@@ -34,8 +36,7 @@
 
   - name: Get the csr
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
     register: csr_result
@@ -50,8 +51,7 @@
 
   - name: Try to approve the csr again (idempotency)
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       approved: false
@@ -66,8 +66,7 @@
   always:
     - name: Delete csr
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: CertificateSigningRequest
         name: "{{ csr_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_certificate/tasks/enrollment-approval.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/enrollment-approval.yml
@@ -2,11 +2,14 @@
 - name: Test approve device enrollment
   vars:
     enrollment_name: ansible-integration-test-enrollment-approval
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create an enrollment request
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       api_version: v1alpha1
@@ -24,8 +27,7 @@
 
   - name: Approve the enrollment request in check mode
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       approved: true
@@ -36,8 +38,7 @@
 
   - name: Get the enrollment request
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
     register: check_result
@@ -50,8 +51,7 @@
 
   - name: Approve the enrollment request
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       approved: true
@@ -67,8 +67,7 @@
 
   - name: Get the enrollment request
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
     register: enrollment_result
@@ -83,8 +82,7 @@
 
   - name: Try to approve the enrollment request again (idempotency)
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       approved: true
@@ -102,8 +100,7 @@
   always:
     - name: Delete enrollment request
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: EnrollmentRequest
         name: "{{ enrollment_name }}"
         state: absent
@@ -111,8 +108,7 @@
     # Approving an enrollment request attempts to create a device, clean it up here as well
     - name: Delete test device
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: Device
         name: "{{ enrollment_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_certificate/tasks/enrollment-denial.yml
+++ b/tests/integration/targets/flightctl_certificate/tasks/enrollment-denial.yml
@@ -2,11 +2,14 @@
 - name: Test approve device enrollment
   vars:
     enrollment_name: ansible-integration-test-enrollment-denail
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create an enrollment request
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       api_version: v1alpha1
@@ -24,8 +27,7 @@
 
   - name: Deny the enrollment request in check mode
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       approved: true
@@ -36,8 +38,7 @@
 
   - name: Get the enrollment request
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
     register: check_result
@@ -50,8 +51,7 @@
 
   - name: Deny the enrollment request
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
       approved: false
@@ -67,8 +67,7 @@
 
   - name: Get the enrollment request
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: EnrollmentRequest
       name: "{{ enrollment_name }}"
     register: enrollment_result
@@ -82,8 +81,7 @@
   always:
     - name: Delete enrollment request
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: EnrollmentRequest
         name: "{{ enrollment_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_enrollment_config_info/tasks/fetch-config.yml
+++ b/tests/integration/targets/flightctl_enrollment_config_info/tasks/fetch-config.yml
@@ -2,11 +2,14 @@
 - name: Test fetching enrollment config
   vars:
     csr_name: ansible-integration-test-enrollment-config-csr
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a csr
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       api_version: v1alpha1
@@ -18,16 +21,14 @@
 
   - name: Approve the csr
     flightctl.edge.flightctl_certificate:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: CertificateSigningRequest
       name: "{{ csr_name }}"
       approved: true
 
   - name: Fetch enrollment config for the csr
     flightctl.edge.flightctl_enrollment_config_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       name: "{{ csr_name }}"
     register: enrollment_config_result
 
@@ -41,8 +42,7 @@
   always:
     - name: Delete csr
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: CertificateSigningRequest
         name: "{{ csr_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_info/tasks/devices.yml
+++ b/tests/integration/targets/flightctl_info/tasks/devices.yml
@@ -5,11 +5,14 @@
     deivce_name_with_label_1: ansible-integration-test-device-label-1
     deivce_name_with_label_2: ansible-integration-test-device-label-2
     fleet_name: ansible-integration-test-fleet
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a test fleet
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Fleet
       name: "{{ fleet_name }}"
       resource_definition:
@@ -24,8 +27,7 @@
 
   - name: Create a test device
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
       resource_definition:
@@ -35,8 +37,7 @@
 
   - name: Get test device
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
     register: device_result
@@ -49,8 +50,7 @@
 
   - name: Get rendered spec for the test device
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name }}"
       rendered: True
@@ -64,8 +64,7 @@
 
   - name: Create a test device with a label
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name_with_label_1 }}"
       api_version: v1alpha1
@@ -76,8 +75,7 @@
 
   - name: Create a second test device with a label
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ deivce_name_with_label_2 }}"
       api_version: v1alpha1
@@ -88,8 +86,7 @@
 
   - name: Query for all devices by label
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       label_selector: machine_type=forklift
     register: device_with_label_result
@@ -104,8 +101,7 @@
 
   - name: Query for all devices by owner
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       owner: "Fleet/{{ fleet_name }}"
     register: device_with_owner_result
@@ -119,8 +115,7 @@
 
   - name: Query for all devices
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
     register: all_devices_result
 
@@ -132,8 +127,7 @@
 
   - name: Query for all devices with summary_only
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       summary_only: True
     register: summary_only_result
@@ -147,8 +141,7 @@
 
   - name: Query for all devices with a limit
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       limit: 2
     register: limit_result
@@ -161,8 +154,7 @@
 
   - name: Use the continue token to query for remaining devices
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       limit: 2
       continue_token: "{{ limit_result.result.metadata.continue }}"
@@ -175,8 +167,7 @@
 
   - name: Query for all devices with a status filter
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       status_filter: ['updated.status=OutOfDate']
     register: status_filter_result
@@ -189,8 +180,7 @@
 
   - name: Query for devices with a filter selector
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       field_selector: "metadata.name!={{ deivce_name }}"
     register: field_selector_result
@@ -204,15 +194,13 @@
   always:
     - name: Delete test devices
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: Device
         state: absent
 
     - name: Delete test fleet
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: Fleet
         name: "{{ fleet_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_info/tasks/fleets.yml
+++ b/tests/integration/targets/flightctl_info/tasks/fleets.yml
@@ -2,11 +2,14 @@
 - name: Test Get Fleet Info
   vars:
     fleet_name: ansible-integration-test-fleet
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a test fleet
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Fleet
       name: "{{ fleet_name }}"
       resource_definition:
@@ -21,8 +24,7 @@
 
   - name: Create test devices
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       name: "{{ item }}"
       resource_definition:
@@ -36,8 +38,7 @@
 
   - name: Fetch fleet
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Fleet
       name: "{{ fleet_name }}"
       summary: True
@@ -53,15 +54,13 @@
   always:
   - name: Delete test devices
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Device
       state: absent
 
   - name: Delete test fleet
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Fleet
       name: "{{ fleet_name }}"
       state: absent

--- a/tests/integration/targets/flightctl_info/tasks/main.yml
+++ b/tests/integration/targets/flightctl_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include_tasks: devices.yml
-- include_tasks: fleets.yml
-- include_tasks: repository.yml
-- include_tasks: resource-sync.yml
+  - include_tasks: devices.yml
+  - include_tasks: fleets.yml
+  - include_tasks: repository.yml
+  - include_tasks: resource-sync.yml

--- a/tests/integration/targets/flightctl_info/tasks/repository.yml
+++ b/tests/integration/targets/flightctl_info/tasks/repository.yml
@@ -2,11 +2,14 @@
 - name: Test Get Repository Info
   vars:
     repository_name: ansible-integration-test-repository
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a test repo
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Repository
       name: "{{ repository_name }}"
       resource_definition:
@@ -16,8 +19,7 @@
 
   - name: Get test repo
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: Repository
       name: "{{ repository_name }}"
     register: repo_result
@@ -31,8 +33,7 @@
   always:
     - name: Delete test repo
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: Repository
         name: "{{ repository_name }}"
         state: absent

--- a/tests/integration/targets/flightctl_info/tasks/resource-sync.yml
+++ b/tests/integration/targets/flightctl_info/tasks/resource-sync.yml
@@ -2,11 +2,14 @@
 - name: Test Get Resource Sync Info
   vars:
     resource_sync_name: ansible-integration-test-resource-sync
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit)}}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: False
   block:
   - name: Create a test resource sync
     flightctl.edge.flightctl:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: ResourceSync
       name: "{{ resource_sync_name }}"
       resource_definition:
@@ -17,8 +20,7 @@
 
   - name: Get test resource sync
     flightctl.edge.flightctl_info:
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_validate_certs: false
+      <<: *connection_info
       kind: ResourceSync
       name: "{{ resource_sync_name }}"
     register: resource_sync_result
@@ -32,8 +34,7 @@
   always:
     - name: Delete test resource sync
       flightctl.edge.flightctl:
-        flightctl_host: "{{ flightctl_host }}"
-        flightctl_validate_certs: false
+        <<: *connection_info
         kind: ResourceSync
         name: "{{ resource_sync_name }}"
         state: absent

--- a/tests/unit/plugins/module_utils/test_api_module.py
+++ b/tests/unit/plugins/module_utils/test_api_module.py
@@ -52,7 +52,7 @@ def test_approve_enrollment_success(mock_api, api_module):
     input = ApprovalOptions(ResourceType.ENROLLMENT, "test-enrollment", True)
     body = EnrollmentRequestApproval.from_dict(input.to_request_params())
     api_module.approve(input)
-    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None)
+    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None, _request_timeout=10)
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -63,7 +63,7 @@ def test_deny_enrollment_success(mock_api, api_module):
     input = ApprovalOptions(ResourceType.ENROLLMENT, "test-enrollment", False)
     body = EnrollmentRequestApproval.from_dict(input.to_request_params())
     api_module.approve(input)
-    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None)
+    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None, _request_timeout=10)
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -84,7 +84,7 @@ def test_approve_csr(mock_api, api_module):
 
     input = ApprovalOptions(ResourceType.CSR, "test-csr", True)
     api_module.approve(input)
-    mock_api_instance.approve_certificate_signing_request.assert_called_with(input.name, _headers=None)
+    mock_api_instance.approve_certificate_signing_request.assert_called_with(input.name, _headers=None, _request_timeout=10)
 
 
 @patch('plugins.module_utils.api_module.DefaultApi')
@@ -94,7 +94,7 @@ def test_approve_csr(mock_api, api_module):
 
     input = ApprovalOptions(ResourceType.CSR, "test-csr", False)
     api_module.approve(input)
-    mock_api_instance.deny_certificate_signing_request.assert_called_with(input.name, _headers=None)
+    mock_api_instance.deny_certificate_signing_request.assert_called_with(input.name, _headers=None, _request_timeout=10)
 
 
 @patch('plugins.module_utils.api_module.DefaultApi')
@@ -106,7 +106,8 @@ def test_token_auth(mock_api, api_module_with_token):
     api_module_with_token.approve(input)
     mock_api_instance.approve_certificate_signing_request.assert_called_with(
         input.name,
-        _headers={'Authorization': 'Bearer test-token'}
+        _headers={'Authorization': 'Bearer test-token'},
+        _request_timeout=10
     )
 
 
@@ -119,5 +120,6 @@ def test_basic_auth(mock_api, api_module_with_user_pass):
     api_module_with_user_pass.approve(input)
     mock_api_instance.approve_certificate_signing_request.assert_called_with(
         input.name,
-        _headers={'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcGFzcw=='}
+        _headers={'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcGFzcw=='},
+        _request_timeout=10
     )

--- a/tests/unit/plugins/module_utils/test_api_module.py
+++ b/tests/unit/plugins/module_utils/test_api_module.py
@@ -25,6 +25,25 @@ def api_module():
     return FlightctlAPIModule(argument_spec={})
 
 
+@pytest.fixture
+def api_module_with_token():
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_token='test-token'
+    ))
+    return FlightctlAPIModule(argument_spec={})
+
+
+@pytest.fixture
+def api_module_with_user_pass():
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_username='test-user',
+        flightctl_password='test-pass'
+    ))
+    return FlightctlAPIModule(argument_spec={})
+
+
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
 def test_approve_enrollment_success(mock_api, api_module):
     mock_api_instance = MagicMock()
@@ -33,7 +52,7 @@ def test_approve_enrollment_success(mock_api, api_module):
     input = ApprovalOptions(ResourceType.ENROLLMENT, "test-enrollment", True)
     body = EnrollmentRequestApproval.from_dict(input.to_request_params())
     api_module.approve(input)
-    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body)
+    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None)
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -44,7 +63,7 @@ def test_deny_enrollment_success(mock_api, api_module):
     input = ApprovalOptions(ResourceType.ENROLLMENT, "test-enrollment", False)
     body = EnrollmentRequestApproval.from_dict(input.to_request_params())
     api_module.approve(input)
-    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body)
+    mock_api_instance.approve_enrollment_request.assert_called_with(input.name, body, _headers=None)
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -65,7 +84,7 @@ def test_approve_csr(mock_api, api_module):
 
     input = ApprovalOptions(ResourceType.CSR, "test-csr", True)
     api_module.approve(input)
-    mock_api_instance.approve_certificate_signing_request.assert_called_with(input.name)
+    mock_api_instance.approve_certificate_signing_request.assert_called_with(input.name, _headers=None)
 
 
 @patch('plugins.module_utils.api_module.DefaultApi')
@@ -75,4 +94,30 @@ def test_approve_csr(mock_api, api_module):
 
     input = ApprovalOptions(ResourceType.CSR, "test-csr", False)
     api_module.approve(input)
-    mock_api_instance.deny_certificate_signing_request.assert_called_with(input.name)
+    mock_api_instance.deny_certificate_signing_request.assert_called_with(input.name, _headers=None)
+
+
+@patch('plugins.module_utils.api_module.DefaultApi')
+def test_token_auth(mock_api, api_module_with_token):
+    mock_api_instance = MagicMock()
+    mock_api.return_value = mock_api_instance
+
+    input = ApprovalOptions(ResourceType.CSR, "test-csr", True)
+    api_module_with_token.approve(input)
+    mock_api_instance.approve_certificate_signing_request.assert_called_with(
+        input.name,
+        _headers={'Authorization': 'Bearer test-token'}
+    )
+
+
+@patch('plugins.module_utils.api_module.DefaultApi')
+def test_basic_auth(mock_api, api_module_with_user_pass):
+    mock_api_instance = MagicMock()
+    mock_api.return_value = mock_api_instance
+
+    input = ApprovalOptions(ResourceType.CSR, "test-csr", True)
+    api_module_with_user_pass.approve(input)
+    mock_api_instance.approve_certificate_signing_request.assert_called_with(
+        input.name,
+        _headers={'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcGFzcw=='}
+    )

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,4 @@
 jsonpatch
 jsonschema
-openapi_schema_validator
 pytest
 git+https://github.com/flightctl/flightctl-python-client.git


### PR DESCRIPTION
Modifies the collection api to accept:
- Access Tokens
  - Parity with the cli and how it is configured to integrate with app gateway currently
  - Can be passed via params or a flightctl config file generated by the cli
- Username / PW
  -  AAP gateway supports accepting basic auth tokens and the proxy will then parse / replace the token with a JWT the flightctl service can then verify

This maps to what the kubernetes.core collection accepts in terms of var options.

Other changes:
- Integration tests can now be run against flightctl servies running with auth enabled
- Request timeouts are now properly passed from the collection options to the request handler
- Removes some unused code and oapi validator dependency