### PR TITLE
EDM-1035: Sanity test fix: Using variable 'result' before assignment

### DIFF
--- a/plugins/module_utils/runner.py
+++ b/plugins/module_utils/runner.py
@@ -100,6 +100,7 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
     label_selector = module.params.get("label_selector")
     state = module.params.get("state")
     changed: bool = False
+    result = None
 
     try:
         get_options = GetOptions(
@@ -147,6 +148,9 @@ def perform_action(module, definition: Dict[str, Any]) -> Tuple[bool, Dict[str, 
                 changed |= True
             except Exception as e:
                 raise FlightctlException(f"Failed to create resource: {e}") from e
+
+    if result is None:
+        raise FlightctlException("No result returned from operation.")
 
     return changed, result.to_dict()
 


### PR DESCRIPTION
There was error, when running make sanity-test.
ERROR: plugins/module_utils/runner.py:151:20: used-before-assignment: Using variable 'result' before assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in resource management operations
	- Added validation to ensure meaningful function output
	- Enhanced robustness of action processing mechanism
	- Updated output format to ensure consistent structure of results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->