### PR TITLE
Add galaxy importer workflow, doc updates before release

### DIFF
--- a/.github/workflows/galaxy-importer.yaml
+++ b/.github/workflows/galaxy-importer.yaml
@@ -1,0 +1,15 @@
+---
+name: Galaxy Importer
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  galaxy_importer:
+    uses: ansible-network/github_actions/.github/workflows/galaxy_importer.yml@main

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Tested with the Ansible Core >= 2.15.0 versions, and the current development ver
 
 This collection requires Python 3.10 or greater.
 
-<!--
+See the [Ansible Core Support Matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) to see which ansible versions are compatible with python versions.
+
+
 ## Installation
 
 The `flightctl.core` collection can be installed with the Ansible Galaxy command-line tool:
@@ -46,13 +48,13 @@ A specific version of the collection can be installed by using the `version` key
 ---
 collections:
   - name: flightctl.core
-    version: 1.0.0
+    version: 0.2.0
 ```
 
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:==1.0.0
+ansible-galaxy collection install flightctl.core:==0.2.0
 ```
 
 The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
@@ -64,7 +66,7 @@ pip install -r requirements.txt
 Refer to the following for more details.
 * [using Ansible collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
 
--->
+
 ## Use Cases
 
 You can either call modules, rulebooks and playbooks by their Fully Qualified Collection Name (FQCN), such as ansible.eda.activation, or you can call modules by their short name if you list the flightctl.core collection in the playbook's collections keyword:
@@ -151,6 +153,37 @@ The easiest way to run tests locally is to:
 - Run `make deploy` from the main flightctl repository
 - Run `make write-integration-config` from this repository to create the proper integration config from your running services
 - Run locally via `make integration-test`
+
+## Publishing New Versions
+
+Currently, the publishing to Ansible Galaxy is manual and requires the following steps:
+
+1. Checkout a release branch
+    1. `git checkout -b release-NEW_VERSION`
+2. Update the version in the following places:
+    1. The `version` in `galaxy.yml`
+    2. This README's referenced versions in the Installation section
+3. Update the CHANGELOG:
+    1. Make sure you have [`antsibull-changelog`](https://pypi.org/project/antsibull-changelog/) installed.
+    2. Make sure there are fragments for all known changes in `changelogs/fragments`.  Info about creating changelog fragments can be found [here](https://docs.ansible.com/ansible/devel/community/development_process.html#creating-a-changelog-fragment)
+    3. Run `antsibull-changelog release`.
+4. Ensure the colleciton tarball builds properly:
+    1. Run `ansible-galaxy collection build`
+    2. Ensure there are no errors and a tarball like `flightctl-core-{some-version}.tar.gz` exists in the current directory
+5. Install and verify the collection tarball locally
+    1. Install the built collection via `ansible-galaxy collection install flightctl-core-{some-version}.tar.gz --force`
+    2. Run a basic playbook to verify functionality (examples can be found in demo/README.md)
+6. Commit the changes and create a PR with the changes. Ensure CI tests pass and merge to main.
+7. Pull and checkout the latest code from the main branch.
+8. Use git to tag the release appropriately:
+    1. `git tag -n` # see current tags and their comments
+    2. `git tag -a NEW_VERSION -m "comment here"` # the comment can be, for example,  "flightctl.core: 1.0.0"
+    3. `git push upstream NEW_VERSION`
+9. Build and push the collection to Galaxy:
+    1. Run `ansible-galaxy collection build`
+    2. Fetch or configure your [Galaxy Token](https://galaxy.ansible.com/ui/token/) if you have not done so already.
+    3. Publish the collection `ansible-galaxy collection publish path/to/built/collection.tar.gz --token=your_token_here`
+10. Verify the new version exists on the [Flightctl Galaxy page](https://galaxy.ansible.com/flightctl/core).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -158,18 +158,18 @@ The easiest way to run tests locally is to:
 
 Currently, the publishing to Ansible Galaxy is manual and requires the following steps:
 
-1. Checkout a release branch
+1. Check out a release branch
     1. `git checkout -b release-NEW_VERSION`
 2. Update the version in the following places:
     1. The `version` in `galaxy.yml`
     2. This README's referenced versions in the Installation section
 3. Update the CHANGELOG:
-    1. Make sure you have [`antsibull-changelog`](https://pypi.org/project/antsibull-changelog/) installed.
-    2. Make sure there are fragments for all known changes in `changelogs/fragments`.  Info about creating changelog fragments can be found [here](https://docs.ansible.com/ansible/devel/community/development_process.html#creating-a-changelog-fragment)
+    1. Install [`antsibull-changelog`](https://pypi.org/project/antsibull-changelog)
+    2. Verify fragments exist for all known changes in `changelogs/fragments`.  Info about creating changelog fragments can be found [here](https://docs.ansible.com/ansible/devel/community/development_process.html#creating-a-changelog-fragment)
     3. Run `antsibull-changelog release`.
-4. Ensure the colleciton tarball builds properly:
+4. Build the collection tarball:
     1. Run `ansible-galaxy collection build`
-    2. Ensure there are no errors and a tarball like `flightctl-core-{some-version}.tar.gz` exists in the current directory
+    2. Verify the tarball `flightctl-core-{some-version}.tar.gz` was created in the current directory without build errors
 5. Install and verify the collection tarball locally
     1. Install the built collection via `ansible-galaxy collection install flightctl-core-{some-version}.tar.gz --force`
     2. Run a basic playbook to verify functionality (examples can be found in demo/README.md)

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ A specific version of the collection can be installed by using the `version` key
 ---
 collections:
   - name: flightctl.core
-    version: 0.2.0
+    version: 1.0.0
 ```
 
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:==0.2.0
+ansible-galaxy collection install flightctl.core:==1.0.0
 ```
 
 The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 0.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -22,7 +22,7 @@ authors:
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
-description: Flight Control Collection
+description: Collection for management of Flight Control resources
 
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
@@ -67,6 +67,10 @@ build_ignore:
   - "demo"
   - ".venv"
   - "venv"
+  - ".github"
+  - ".config"
+  - ".ruff*"
+  - ".tox*"
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.2.0
+version: 1.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Includes a few small updates to get in before the "actual" release PR for version 0.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new GitHub Actions workflow for Galaxy Importer

- **Documentation**
  - Updated README with new publishing process
  - Refined collection description

- **Chores**
  - Downgraded collection version from 1.0.0 to 0.2.0
  - Updated build ignore list for collection packaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->