### PR TITLE
Adding Downstream build script

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FLIGHTCTL_REF: v0.7.1
+
 jobs:
   integration-tests:
     runs-on: "ubuntu-latest"
@@ -23,7 +26,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'flightctl/flightctl'
-          ref: v0.7.0
+          ref: ${{ env.FLIGHTCTL_REF }}
+
 
       - name: Setup dependencies for flightctl
         uses: ./.github/actions/setup-dependencies
@@ -65,7 +69,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'flightctl/flightctl'
-          ref: v0.7.0
+          ref: ${{ env.FLIGHTCTL_REF }}
 
       - name: Setup dependencies for flightctl
         uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'flightctl/flightctl'
-          ref: v0.5.0
+          ref: v0.7.0
 
       - name: Setup dependencies for flightctl
         uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ansible: stable-2.16
-            python: "3.10"
+          - ansible: ${{ vars.ANSIBLE_VERSION || 'stable-2.16' }}
+            python: ${{ vars.PYTHON_VERSION || '3.12' }}
     steps:
       - name: Checkout flightctl
         uses: actions/checkout@v4
@@ -61,8 +61,8 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ansible: stable-2.16
-            python: "3.10"
+          - ansible: ${{ vars.ANSIBLE_VERSION || 'stable-2.16' }}
+            python: ${{ vars.PYTHON_VERSION || '3.12' }}
             
     steps:
       - name: Checkout flightctl
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.versions.python }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -50,3 +50,29 @@ jobs:
           target-python-version: ${{ matrix.versions.python }}
           testing-type: integration
           collection-src-directory: ./collection
+
+  test-integration-downstream:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    needs: integration-tests  # Ensure upstream tests pass before running downstream tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible ansible-lint
+
+      - name: Write integration config
+        run: make write-integration-config
+
+      - name: Run downstream integration tests
+        run: |
+          cd ci
+          ./downstream.sh -i

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -52,12 +52,36 @@ jobs:
           collection-src-directory: ./collection
 
   test-integration-downstream:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    needs: integration-tests  # Ensure upstream tests pass before running downstream tests
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        versions:
+          - ansible: stable-2.16
+            python: "3.10"
+            
     steps:
+      - name: Checkout flightctl
+        uses: actions/checkout@v4
+        with:
+          repository: 'flightctl/flightctl'
+          ref: v0.5.0
+
+      - name: Setup dependencies for flightctl
+        uses: ./.github/actions/setup-dependencies
+        with:
+          setup_podman4: yes
+
+      - name: Start flightctl services
+        run: make deploy
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with: 
+          path: collection
+
+      - name: Write integration config
+        run: make write-integration-config
+        working-directory: ./collection
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -69,10 +93,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install ansible ansible-lint
 
-      - name: Write integration config
-        run: make write-integration-config
-
       - name: Run downstream integration tests
         run: |
           cd ci
           ./downstream.sh -i
+        working-directory: ./collection

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,6 +53,7 @@ jobs:
 
   test-integration-downstream:
     runs-on: "ubuntu-latest"
+    needs: integration-tests
     strategy:
       matrix:
         versions:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ansible: stable-2.16
-            python: "3.10"
+          - ansible: ${{ vars.ANSIBLE_VERSION || 'stable-2.16' }}
+            python: ${{ vars.PYTHON_VERSION || '3.12' }}
     steps:
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ vars.PYTHON_VERSION || '3.12' }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -27,3 +27,26 @@ jobs:
           origin-python-version: ${{ matrix.versions.python }}
           target-python-version: ${{ matrix.versions.python }}
           testing-type: sanity
+
+  test-sanity-downstream:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    needs: test-sanity  # Ensure upstream tests pass before running downstream tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible ansible-lint
+
+      - name: Run downstream sanity tests
+        run: |
+          cd ci
+          ./downstream.sh -s

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-unit:
+  test-unit-upstream:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -27,3 +27,26 @@ jobs:
           origin-python-version: ${{ matrix.versions.python }}
           target-python-version: ${{ matrix.versions.python }}
           testing-type: units
+
+  test-unit-downstream:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    needs: test-unit-upstream  # Ensure upstream tests pass before running downstream tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible ansible-lint
+
+      - name: Run downstream unit tests
+        run: |
+          cd ci
+          ./downstream.sh -u

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ansible: stable-2.16
-            python: "3.10"
+          - ansible: ${{ vars.ANSIBLE_VERSION || 'stable-2.16' }}
+            python: ${{ vars.PYTHON_VERSION || '3.12' }}
     steps:
       - name: Perform unit testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ vars.PYTHON_VERSION || '3.12' }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,12 @@ v1.0.0
 Release Summary
 ---------------
 
-Added support for FlightCTL API v0.7.1.
+Added support for Flight Control API v0.7.1.
 
 Minor Changes
 -------------
 
-- Updated the Ansible collection to support FlightCTL API version 0.7.1.
+- Updated the Ansible collection to support Flight Control API version 0.7.1.
 - Version bump for Automation Hub publishing
 
 v0.7.0
@@ -24,15 +24,15 @@ v0.7.0
 Release Summary
 ---------------
 
-Added support for FlightCTL API v0.7.
+Added support for Flight Control API v0.7.
 
 Major Changes
 -------------
 
 - Added Flight Control console connection plugin
 - Added support for dynamic inventory plugin
-- Added support for new features in FlightCTL API v0.7.
-- Updated the Ansible collection to support FlightCTL API version 0.7.
+- Added support for new features in Flight Control API v0.7.
+- Updated the Ansible collection to support Flight Control API version 0.7.
 
 Bugfixes
 --------
@@ -58,12 +58,12 @@ v0.6.0
 Release Summary
 ---------------
 
-Added support for FlightCTL API v0.6.
+Added support for Flight Control API v0.6.
 
 Major Changes
 -------------
 
-- Updated the Ansible collection to support FlightCTL API version 0.6.
+- Updated the Ansible collection to support Flight Control API version 0.6.
 
 v0.5.0
 ======
@@ -71,13 +71,13 @@ v0.5.0
 Release Summary
 ---------------
 
-Added support for FlightCTL API v0.5.
+Added support for Flight Control API v0.5.
 
 Major Changes
 -------------
 
 - Added support for Device decommissioning.
-- Updated the Ansible collection to support FlightCTL API version 0.5.
+- Updated the Ansible collection to support Flight Control API version 0.5.
 
 v0.2.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,21 @@
-============================
-flightctl.core Release Notes
-============================
+==================================
+flightctl collection Release Notes
+==================================
 
 .. contents:: Topics
+
+v0.7.1
+======
+
+Release Summary
+---------------
+
+Added support for FlightCTL API v0.7.1.
+
+Minor Changes
+-------------
+
+- Updated the Ansible collection to support FlightCTL API version 0.7.1.
 
 v0.7.0
 ======
@@ -15,7 +28,7 @@ Added support for FlightCTL API v0.7.
 Major Changes
 -------------
 
-- Added flight control console connection plugin
+- Added Flight Control console connection plugin
 - Added support for dynamic inventory plugin
 - Added support for new features in FlightCTL API v0.7.
 - Updated the Ansible collection to support FlightCTL API version 0.7.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ flightctl.core Release Notes
 
 .. contents:: Topics
 
-v0.5.0
+v1.0.0
 ======
 
 Release Summary

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ flightctl collection Release Notes
 
 .. contents:: Topics
 
-v0.7.1
+v1.0.0
 ======
 
 Release Summary
@@ -16,6 +16,7 @@ Minor Changes
 -------------
 
 - Updated the Ansible collection to support FlightCTL API version 0.7.1.
+- Version bump for Automation Hub publishing
 
 v0.7.0
 ======

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+## Publishing New Versions
+
+### Publishing to Ansible Galaxy
+
+Currently, the publishing to Ansible Galaxy is manual and requires the following steps:
+
+1. Check out a release branch
+    1. `git checkout -b release-NEW_VERSION`
+2. Update the version in the following places:
+    1. The `version` in `galaxy.yml`
+    2. This README's referenced versions in the Installation section
+3. Update the CHANGELOG:
+    1. Install [`antsibull-changelog`](https://pypi.org/project/antsibull-changelog)
+    2. Verify fragments exist for all known changes in `changelogs/fragments`.  Info about creating changelog fragments can be found [here](https://docs.ansible.com/ansible/devel/community/development_process.html#creating-a-changelog-fragment)
+    3. Run `antsibull-changelog release`.
+4. Build the collection tarball:
+    1. Run `ansible-galaxy collection build`
+    2. Verify the tarball `flightctl-core-{some-version}.tar.gz` was created in the current directory without build errors
+5. Install and verify the collection tarball locally
+    1. Install the built collection via `ansible-galaxy collection install flightctl-core-{some-version}.tar.gz --force`
+    2. Run a basic playbook to verify functionality (examples can be found in demo/README.md)
+6. Commit the changes and create a PR with the changes. Ensure CI tests pass and merge to main.
+7. Pull and checkout the latest code from the main branch.
+8. Use git to tag the release appropriately:
+    1. `git tag -n` # see current tags and their comments
+    2. `git tag -a NEW_VERSION -m "comment here"` # the comment can be, for example,  "flightctl.core: 0.7.0"
+    3. `git push origin NEW_VERSION`
+9. Build and push the collection to Galaxy:
+    1. Run `ansible-galaxy collection build`
+    2. Fetch or configure your [Galaxy Token](https://galaxy.ansible.com/ui/token/) if you have not done so already.
+    3. Publish the collection `ansible-galaxy collection publish path/to/built/collection.tar.gz --token=your_token_here`
+10. Verify the new version exists on the [Flightctl Galaxy page](https://galaxy.ansible.com/flightctl/core).
+
+### Publishing to Automation Hub
+
+#### Build the downstream Collection
+
+To create the downstream build for Automation Hub, use the provided `downstream.sh` script. Follow these steps:
+
+1. Navigate to the `ci` directory where the `downstream.sh` script is located:
+2. Run the downstream.sh script with the -b option to build the downstream release:
+```shell
+./downstream.sh -b
+```
+3. Verify the tarball `redhat-edge_manager-{some-version}.tar.gz` was created in the current directory without build errors
+
+
+#### Using the Automation Hub User Interface
+
+To upload your collection using the Automation Hub user interface:
+
+1. Log in to the **Red Hat Ansible Automation Platform**.
+2. Navigate to **Automation Hub > My Namespaces**.
+3. Click a namespace.
+4. Click **Upload collection**.
+5. In the **New collection** modal, click **Select file**. Locate the `.tar.gz` file on your system.
+6. Click **Upload**.
+
+#### Using the `ansible-galaxy` Client
+
+To upload a collection using the `ansible-galaxy` client, enter the following command:
+
+```shell
+ansible-galaxy collection publish path/to/redhat-edge_manager-{some-version}.tar.gz --api-key=SECRET
+```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The easiest way to run tests locally is to:
 
 ## Support
 
-redhat.edge_manager collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). IIf you encounter issues or have questions, you can submit a support request through the following channels:
+redhat.edge_manager collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you encounter issues or have questions, you can submit a support request through the following channels:
  - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/flightctl/flightctl-ansible/issues).
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Tested with the Ansible Core >= 2.15.0 versions, and the current development ver
 
 This collection requires Python 3.10 or greater.
 
+### Ansible Automation Platform compatibility  
+  
+If used with Ansible Automation Platform (AAP), the minimum supported version is 2.5.20250326 or greater.  
+  
+### Flight Control Service compatibility  
+  
+Requires Flight Control version 0.7 or greater.
+
 See the [Ansible Core Support Matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) to see which ansible versions are compatible with python versions.
 
 
@@ -54,7 +62,7 @@ collections:
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:==0.7.0
+ansible-galaxy collection install flightctl.core:0.7.0
 ```
 
 The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
@@ -67,7 +75,7 @@ Refer to the following for more details.
 * [using Ansible collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
 
 
-## Use Cases
+## Usage
 
 You can either call modules, rulebooks and playbooks by their Fully Qualified Collection Name (FQCN), such as flightctl.core, or you can call modules by their short name if you list the flightctl.core collection in the playbook's collections keyword:
 
@@ -154,75 +162,9 @@ The easiest way to run tests locally is to:
 - Run `make write-integration-config` from this repository to create the proper integration config from your running services
 - Run locally via `make integration-test`
 
-## Publishing New Versions
-
-### Publishing to Ansible Galaxy
-
-Currently, the publishing to Ansible Galaxy is manual and requires the following steps:
-
-1. Check out a release branch
-    1. `git checkout -b release-NEW_VERSION`
-2. Update the version in the following places:
-    1. The `version` in `galaxy.yml`
-    2. This README's referenced versions in the Installation section
-3. Update the CHANGELOG:
-    1. Install [`antsibull-changelog`](https://pypi.org/project/antsibull-changelog)
-    2. Verify fragments exist for all known changes in `changelogs/fragments`.  Info about creating changelog fragments can be found [here](https://docs.ansible.com/ansible/devel/community/development_process.html#creating-a-changelog-fragment)
-    3. Run `antsibull-changelog release`.
-4. Build the collection tarball:
-    1. Run `ansible-galaxy collection build`
-    2. Verify the tarball `flightctl-core-{some-version}.tar.gz` was created in the current directory without build errors
-5. Install and verify the collection tarball locally
-    1. Install the built collection via `ansible-galaxy collection install flightctl-core-{some-version}.tar.gz --force`
-    2. Run a basic playbook to verify functionality (examples can be found in demo/README.md)
-6. Commit the changes and create a PR with the changes. Ensure CI tests pass and merge to main.
-7. Pull and checkout the latest code from the main branch.
-8. Use git to tag the release appropriately:
-    1. `git tag -n` # see current tags and their comments
-    2. `git tag -a NEW_VERSION -m "comment here"` # the comment can be, for example,  "flightctl.core: 0.7.0"
-    3. `git push origin NEW_VERSION`
-9. Build and push the collection to Galaxy:
-    1. Run `ansible-galaxy collection build`
-    2. Fetch or configure your [Galaxy Token](https://galaxy.ansible.com/ui/token/) if you have not done so already.
-    3. Publish the collection `ansible-galaxy collection publish path/to/built/collection.tar.gz --token=your_token_here`
-10. Verify the new version exists on the [Flightctl Galaxy page](https://galaxy.ansible.com/flightctl/core).
-
-### Publishing to Automation Hub
-
-#### Build the downstream Collection
-
-To create the downstream build for Automation Hub, use the provided `downstream.sh` script. Follow these steps:
-
-1. Navigate to the `ci` directory where the `downstream.sh` script is located:
-2. Run the downstream.sh script with the -b option to build the downstream release:
-```shell
-./downstream.sh -b
-```
-3. Verify the tarball `redhat-edge_manager-{some-version}.tar.gz` was created in the current directory without build errors
-
-
-#### Using the Automation Hub User Interface
-
-To upload your collection using the Automation Hub user interface:
-
-1. Log in to the **Red Hat Ansible Automation Platform**.
-2. Navigate to **Automation Hub > My Namespaces**.
-3. Click a namespace.
-4. Click **Upload collection**.
-5. In the **New collection** modal, click **Select file**. Locate the `.tar.gz` file on your system.
-6. Click **Upload**.
-
-#### Using the `ansible-galaxy` Client
-
-To upload a collection using the `ansible-galaxy` client, enter the following command:
-
-```shell
-ansible-galaxy collection publish path/to/redhat-edge_manager-{some-version}.tar.gz --api-key=SECRET
-```
-
 ## Support
 
-If you encounter issues or have questions, you can submit a support request through the following channels:
+redhat.edge_manager collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). IIf you encounter issues or have questions, you can submit a support request through the following channels:
  - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/flightctl/flightctl-ansible/issues).
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ A specific version of the collection can be installed by using the `version` key
 ---
 collections:
   - name: flightctl.core
-    version: 0.7.0
+    version: 1.0.0
 ```
 
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:0.7.0
+ansible-galaxy collection install flightctl.core:1.0.0
 ```
 
 The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
@@ -164,7 +164,7 @@ The easiest way to run tests locally is to:
 
 ## Support
 
-flightctl.core collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you encounter issues or have questions, you can submit a support request through the following channels:
+flightctl.core collection v1.0.0 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you encounter issues or have questions, you can submit a support request through the following channels:
  - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/flightctl/flightctl-ansible/issues).
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The easiest way to run tests locally is to:
 
 ## Support
 
-redhat.edge_manager collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you encounter issues or have questions, you can submit a support request through the following channels:
+flightctl.core collection v0.7.1 is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you encounter issues or have questions, you can submit a support request through the following channels:
  - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/flightctl/flightctl-ansible/issues).
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ A specific version of the collection can be installed by using the `version` key
 ---
 collections:
   - name: flightctl.core
-    version: 0.2.0
+    version: 1.0.0
 ```
 
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:==0.2.0
+ansible-galaxy collection install flightctl.core:==1.0.0
 ```
 
 The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
@@ -156,6 +156,8 @@ The easiest way to run tests locally is to:
 
 ## Publishing New Versions
 
+### Publishing to Ansible Galaxy
+
 Currently, the publishing to Ansible Galaxy is manual and requires the following steps:
 
 1. Check out a release branch
@@ -185,6 +187,39 @@ Currently, the publishing to Ansible Galaxy is manual and requires the following
     3. Publish the collection `ansible-galaxy collection publish path/to/built/collection.tar.gz --token=your_token_here`
 10. Verify the new version exists on the [Flightctl Galaxy page](https://galaxy.ansible.com/flightctl/core).
 
+### Publishing to Automation Hub
+
+#### Build the downstream Collection
+
+To create the downstream build for Automation Hub, use the provided `downstream.sh` script. Follow these steps:
+
+1. Navigate to the `ci` directory where the `downstream.sh` script is located:
+2. Run the downstream.sh script with the -b option to build the downstream release:
+```shell
+./downstream.sh -b
+```
+3. Verify the tarball `redhat-edge_manager-{some-version}.tar.gz` was created in the current directory without build errors
+
+
+#### Using the Automation Hub User Interface
+
+To upload your collection using the Automation Hub user interface:
+
+1. Log in to the **Red Hat Ansible Automation Platform**.
+2. Navigate to **Automation Hub > My Namespaces**.
+3. Click a namespace.
+4. Click **Upload collection**.
+5. In the **New collection** modal, click **Select file**. Locate the `.tar.gz` file on your system.
+6. Click **Upload**.
+
+#### Using the `ansible-galaxy` Client
+
+To upload a collection using the `ansible-galaxy` client, enter the following command:
+
+```shell
+ansible-galaxy collection publish path/to/redhat-edge_manager-{some-version}.tar.gz --api-key=SECRET
+```
+
 ## Support
 
 If you encounter issues or have questions, you can submit a support request through the following channels:
@@ -192,7 +227,7 @@ If you encounter issues or have questions, you can submit a support request thro
 
 ## Release notes
 
-See the [changelog](https://github.com/flightctl/flightctl-ansible/blob/main/CHANGELOG.md).
+See the [changelog](https://github.com/flightctl/flightctl-ansible/blob/main/CHANGELOG.rst).
 
 ## Related Information
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,24 +3,24 @@ releases:
   0.2.0:
     changes:
       breaking_changes:
-        - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
-        - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
-        - Renamed `flightctl_resource` module (previously `flightctl`)
-        - Renamed collection to `core` (previously `edge`)
+      - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
+      - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
+      - Renamed `flightctl_resource` module (previously `flightctl`)
+      - Renamed collection to `core` (previously `edge`)
       release_summary: This release contains the initial documented release of the
         Flightctl collection
     fragments:
-      - breaking_changes.yml
-      - release_summary.yml
+    - breaking_changes.yml
+    - release_summary.yml
     release_date: '2025-01-20'
   0.5.0:
     changes:
       major_changes:
-        - Updated the Ansible collection to support FlightCTL API version 0.5.
-        - Added support for Device decommissioning.
+      - Added support for Device decommissioning.
+      - Updated the Ansible collection to support FlightCTL API version 0.5.
       release_summary: Added support for FlightCTL API v0.5.
     fragments:
-      - flightctl_1.0_update.yml
+    - flightctl_0.5_update.yml
     release_date: '2025-04-01'
   0.6.0:
     changes:
@@ -35,7 +35,7 @@ releases:
       bugfixes:
       - auth documentation - fixed env var names to align with module usage
       major_changes:
-      - Added flight control console connection plugin
+      - Added Flight Control console connection plugin
       - Added support for dynamic inventory plugin
       - Added support for new features in FlightCTL API v0.7.
       - Updated the Ansible collection to support FlightCTL API version 0.7.
@@ -53,3 +53,11 @@ releases:
         name: flightctl
         namespace: null
     release_date: '2025-05-12'
+  0.7.1:
+    changes:
+      minor_changes:
+      - Updated the Ansible collection to support FlightCTL API version 0.7.1.
+      release_summary: Added support for FlightCTL API v0.7.1.
+    fragments:
+    - flightctl_0.7.1_update.yml
+    release_date: '2025-05-15'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -25,7 +25,7 @@ releases:
   0.6.0:
     changes:
       major_changes:
-       - Updated the Ansible collection to support FlightCTL API version 0.6.
+        - Updated the Ansible collection to support FlightCTL API version 0.6.
       release_summary: Added support for FlightCTL API v0.6.
     fragments:
       - flightctl_0.6_update.yml
@@ -33,7 +33,7 @@ releases:
   0.7.0:
     changes:
       bugfixes:
-       - auth documentation - fixed env var names to align with module usage
+        - auth documentation - fixed env var names to align with module usage
       major_changes:
         - Added Flight Control console connection plugin
         - Added support for dynamic inventory plugin
@@ -45,13 +45,13 @@ releases:
       - flightctl_0.7_update.yml
     plugins:
       connection:
-      - description: Connect to Flight Control managed devices.
-        name: flightctl_console
-        namespace: null
+        - description: Connect to Flight Control managed devices.
+          name: flightctl_console
+          namespace: null
       inventory:
-      - description: Returns Ansible inventory using Flight Control as source.
-        name: flightctl
-        namespace: null
+        - description: Returns Ansible inventory using Flight Control as source.
+          name: flightctl
+          namespace: null
     release_date: '2025-05-12'
   1.0.0:
     changes:

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,46 +3,46 @@ releases:
   0.2.0:
     changes:
       breaking_changes:
-      - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
-      - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
-      - Renamed `flightctl_resource` module (previously `flightctl`)
-      - Renamed collection to `core` (previously `edge`)
+        - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
+        - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
+        - Renamed `flightctl_resource` module (previously `flightctl`)
+        - Renamed collection to `core` (previously `edge`)
       release_summary: This release contains the initial documented release of the
         Flightctl collection
     fragments:
-    - breaking_changes.yml
-    - release_summary.yml
+      - breaking_changes.yml
+      - release_summary.yml
     release_date: '2025-01-20'
   0.5.0:
     changes:
       major_changes:
-      - Added support for Device decommissioning.
-      - Updated the Ansible collection to support FlightCTL API version 0.5.
+        - Added support for Device decommissioning.
+        - Updated the Ansible collection to support FlightCTL API version 0.5.
       release_summary: Added support for FlightCTL API v0.5.
     fragments:
-    - flightctl_0.5_update.yml
+      - flightctl_0.5_update.yml
     release_date: '2025-04-01'
   0.6.0:
     changes:
       major_changes:
-      - Updated the Ansible collection to support FlightCTL API version 0.6.
+       - Updated the Ansible collection to support FlightCTL API version 0.6.
       release_summary: Added support for FlightCTL API v0.6.
     fragments:
-    - flightctl_0.6_update.yml
+      - flightctl_0.6_update.yml
     release_date: '2025-04-22'
   0.7.0:
     changes:
       bugfixes:
-      - auth documentation - fixed env var names to align with module usage
+       - auth documentation - fixed env var names to align with module usage
       major_changes:
-      - Added Flight Control console connection plugin
-      - Added support for dynamic inventory plugin
-      - Added support for new features in FlightCTL API v0.7.
-      - Updated the Ansible collection to support FlightCTL API version 0.7.
+        - Added Flight Control console connection plugin
+        - Added support for dynamic inventory plugin
+        - Added support for new features in FlightCTL API v0.7.
+        - Updated the Ansible collection to support FlightCTL API version 0.7.
       release_summary: Added support for FlightCTL API v0.7.
     fragments:
-    - add-flightctl-console-connection-plugin.yml
-    - flightctl_0.7_update.yml
+      - add-flightctl-console-connection-plugin.yml
+      - flightctl_0.7_update.yml
     plugins:
       connection:
       - description: Connect to Flight Control managed devices.
@@ -53,11 +53,12 @@ releases:
         name: flightctl
         namespace: null
     release_date: '2025-05-12'
-  0.7.1:
+  1.0.0:
     changes:
       minor_changes:
-      - Updated the Ansible collection to support FlightCTL API version 0.7.1.
+        - Updated the Ansible collection to support FlightCTL API version 0.7.1.
+        - Version bump for Automation Hub publishing
       release_summary: Added support for FlightCTL API v0.7.1.
     fragments:
-    - flightctl_0.7.1_update.yml
+      - flightctl_1.0.0_update.yml
     release_date: '2025-05-15'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -17,16 +17,16 @@ releases:
     changes:
       major_changes:
         - Added support for Device decommissioning.
-        - Updated the Ansible collection to support FlightCTL API version 0.5.
-      release_summary: Added support for FlightCTL API v0.5.
+        - Updated the Ansible collection to support Flight Control API version 0.5.
+      release_summary: Added support for Flight Control API v0.5.
     fragments:
       - flightctl_0.5_update.yml
     release_date: '2025-04-01'
   0.6.0:
     changes:
       major_changes:
-        - Updated the Ansible collection to support FlightCTL API version 0.6.
-      release_summary: Added support for FlightCTL API v0.6.
+        - Updated the Ansible collection to support Flight Control API version 0.6.
+      release_summary: Added support for Flight Control API v0.6.
     fragments:
       - flightctl_0.6_update.yml
     release_date: '2025-04-22'
@@ -37,9 +37,9 @@ releases:
       major_changes:
         - Added Flight Control console connection plugin
         - Added support for dynamic inventory plugin
-        - Added support for new features in FlightCTL API v0.7.
-        - Updated the Ansible collection to support FlightCTL API version 0.7.
-      release_summary: Added support for FlightCTL API v0.7.
+        - Added support for new features in Flight Control API v0.7.
+        - Updated the Ansible collection to support Flight Control API version 0.7.
+      release_summary: Added support for Flight Control API v0.7.
     fragments:
       - add-flightctl-console-connection-plugin.yml
       - flightctl_0.7_update.yml
@@ -56,9 +56,9 @@ releases:
   1.0.0:
     changes:
       minor_changes:
-        - Updated the Ansible collection to support FlightCTL API version 0.7.1.
+        - Updated the Ansible collection to support Flight Control API version 0.7.1.
         - Version bump for Automation Hub publishing
-      release_summary: Added support for FlightCTL API v0.7.1.
+      release_summary: Added support for Flight Control API v0.7.1.
     fragments:
       - flightctl_1.0.0_update.yml
     release_date: '2025-05-15'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,22 +3,22 @@ releases:
   0.2.0:
     changes:
       breaking_changes:
-      - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
-      - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
-      - Renamed `flightctl_resource` module (previously `flightctl`)
-      - Renamed collection to `core` (previously `edge`)
+        - Renamed `flightctl_certificate_management` module (previously `flightctl_certificate`)
+        - Renamed `flightctl_resource_info` module (previously `flightctl_info`)
+        - Renamed `flightctl_resource` module (previously `flightctl`)
+        - Renamed collection to `core` (previously `edge`)
       release_summary: This release contains the initial documented release of the
         Flightctl collection
     fragments:
-    - breaking_changes.yml
-    - release_summary.yml
+      - breaking_changes.yml
+      - release_summary.yml
     release_date: '2025-01-20'
-  0.5.0:
+  1.0.0:
     changes:
       major_changes:
-      - Updated the Ansible collection to support FlightCTL API version 0.5.
-      - Added support for Device decommissioning.
+        - Updated the Ansible collection to support FlightCTL API version 0.5.
+        - Added support for Device decommissioning.
       release_summary: Added support for FlightCTL API v0.5.
     fragments:
-    - flightctl_0.5_update.yml
+      - flightctl_1.0_update.yml
     release_date: '2025-04-01'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -11,26 +11,26 @@ mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments
 output_formats:
-- rst
+  - rst
 prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sanitize_changelog: true
 sections:
-- - major_changes
-  - Major Changes
-- - minor_changes
-  - Minor Changes
-- - breaking_changes
-  - Breaking Changes / Porting Guide
-- - deprecated_features
-  - Deprecated Features
-- - removed_features
-  - Removed Features (previously deprecated)
-- - security_fixes
-  - Security Fixes
-- - bugfixes
-  - Bugfixes
-- - known_issues
-  - Known Issues
-title: flightctl.core
+  - - major_changes
+    - Major Changes
+  - - minor_changes
+    - Minor Changes
+  - - breaking_changes
+    - Breaking Changes / Porting Guide
+  - - deprecated_features
+    - Deprecated Features
+  - - removed_features
+    - Removed Features (previously deprecated)
+  - - security_fixes
+    - Security Fixes
+  - - bugfixes
+    - Bugfixes
+  - - known_issues
+    - Known Issues
+title: flightctl collection
 trivial_section_name: trivial

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -9,7 +9,7 @@
 #       - All functions are prefixed with f_ so it's obvious where they come
 #         from when in use throughout the script
 
-DOWNSTREAM_VERSION="0.7.1"
+DOWNSTREAM_VERSION="1.0.0"
 KEEP_DOWNSTREAM_TMPDIR="${KEEP_DOWNSTREAM_TMPDIR:-''}"
 INSTALL_DOWNSTREAM_COLLECTION_PATH="${INSTALL_DOWNSTREAM_COLLECTION_PATH:-}"
 _build_dir=""

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -14,6 +14,10 @@ KEEP_DOWNSTREAM_TMPDIR="${KEEP_DOWNSTREAM_TMPDIR:-''}"
 INSTALL_DOWNSTREAM_COLLECTION_PATH="${INSTALL_DOWNSTREAM_COLLECTION_PATH:-}"
 _build_dir=""
 
+# Get the absolute path of the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
 f_log_info()
 {
     printf "%s:LOG:INFO: %s\n" "${0}" "${1}"
@@ -60,7 +64,6 @@ f_prep()
         README.md
         Makefile
         requirements.txt
-        tox.ini
     )
 
     # Directories to recursively copy downstream (relative repo root dir path)
@@ -104,11 +107,11 @@ f_create_collection_dir_structure()
     # Create the Collection
     for f_name in "${_file_manifest[@]}";
     do
-        cp "./${f_name}" "${_build_dir}/${f_name}"
+        cp "${ROOT_DIR}/${f_name}" "${_build_dir}/${f_name}"
     done
     for d_name in "${_dir_manifest[@]}";
     do
-        cp -r "./${d_name}" "${_build_dir}/${d_name}"
+        cp -r "${ROOT_DIR}/${d_name}" "${_build_dir}/${d_name}"
     done
     if [ -n "${_file_exclude:-}" ]; then
         for exclude_file in "${_file_exclude[@]}";
@@ -125,7 +128,7 @@ f_copy_collection_to_working_dir()
     f_log_info "Copying built collection to working dir"
     # Copy the Collection build result into original working dir
     f_log_info "Copying built collection *.tar.gz into ./"
-    cp "${_build_dir}"/*.tar.gz ./
+    cp "${_build_dir}"/*.tar.gz "${ROOT_DIR}/"
     # Install downstream collection into provided path
     if [[ -n ${INSTALL_DOWNSTREAM_COLLECTION_PATH} ]]; then
         f_log_info "Installing built collection *.tar.gz into ${INSTALL_DOWNSTREAM_COLLECTION_PATH}"

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -18,13 +18,11 @@ _build_dir=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
-f_log_info()
-{
+f_log_info() {
     printf "%s:LOG:INFO: %s\n" "${0}" "${1}"
 }
 
-f_show_help()
-{
+f_show_help() {
     printf "Usage: downstream.sh [OPTION]\n"
     printf "\t-s\t\tCreate a temporary downstream release and perform sanity tests.\n"
     printf "\t-u\t\tCreate a temporary downstream release and perform unit tests.\n"
@@ -32,8 +30,7 @@ f_show_help()
     printf "\t-b\t\tBuild the downstream release.\n"
 }
 
-f_text_sub()
-{
+f_text_sub() {
     f_log_info "Substituting text in files"
 
     find "${_build_dir}" -type f -exec sed -i.bak "s/flightctl\.core/redhat.edge_manager/g" {} \;
@@ -50,8 +47,7 @@ f_text_sub()
     find "${_build_dir}" -type f -name "*.bak" -delete
 }
 
-f_prep()
-{
+f_prep() {
     f_log_info "Creating temporary build directory"
     # Array of excluded files from downstream build (relative path)
     _file_exclude=(
@@ -81,8 +77,7 @@ f_prep()
     mkdir -p "${_build_dir}"
 }
 
-f_cleanup()
-{
+f_cleanup() {
     f_log_info "Cleaning up"
     if [[ -n "${_build_dir}" ]]; then
         if [[ -z ${KEEP_DOWNSTREAM_TMPDIR} ]]; then
@@ -96,14 +91,12 @@ f_cleanup()
 # Exit and handle cleanup processes if needed
 trap f_cleanup EXIT
 
-f_exit()
-{
+f_exit() {
     f_cleanup
     exit "$0"
 }
 
-f_create_collection_dir_structure()
-{
+f_create_collection_dir_structure() {
     f_log_info "Creating collection directory structure"
     # Create the Collection
     for f_name in "${_file_manifest[@]}";
@@ -124,8 +117,7 @@ f_create_collection_dir_structure()
     fi
 }
 
-f_copy_collection_to_working_dir()
-{
+f_copy_collection_to_working_dir() {
     f_log_info "Copying built collection to working dir"
     # Copy the Collection build result into original working dir
     f_log_info "Copying built collection *.tar.gz into ./"
@@ -138,16 +130,14 @@ f_copy_collection_to_working_dir()
     rm -f "${_build_dir}"/*.tar.gz
 }
 
-f_common_steps()
-{
+f_common_steps() {
     f_prep
     f_create_collection_dir_structure
     f_text_sub
 }
 
 # Run the test sanity scenario
-f_test_sanity_option()
-{
+f_test_sanity_option() {
     f_log_info "Running Sanity Tests"
     f_common_steps
     pushd "${_build_dir}" || return
@@ -157,8 +147,7 @@ f_test_sanity_option()
 }
 
 # Run the test integration
-f_test_integration_option()
-{
+f_test_integration_option() {
     f_log_info "Running Integration Tests"
     f_common_steps
     pushd "${_build_dir}" || return
@@ -168,8 +157,7 @@ f_test_integration_option()
 }
 
 # Run the test units
-f_test_units_option()
-{
+f_test_units_option() {
     f_log_info "Running Unit Tests"
     f_common_steps
     pushd "${_build_dir}" || return
@@ -179,8 +167,7 @@ f_test_units_option()
 }
 
 # Run the build scenario
-f_build_option()
-{
+f_build_option() {
     f_log_info "Building Collection"
     f_common_steps
     pushd "${_build_dir}" || return

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -9,7 +9,7 @@
 #       - All functions are prefixed with f_ so it's obvious where they come
 #         from when in use throughout the script
 
-DOWNSTREAM_VERSION="1.0.0"
+DOWNSTREAM_VERSION="0.7.1"
 KEEP_DOWNSTREAM_TMPDIR="${KEEP_DOWNSTREAM_TMPDIR:-''}"
 INSTALL_DOWNSTREAM_COLLECTION_PATH="${INSTALL_DOWNSTREAM_COLLECTION_PATH:-}"
 _build_dir=""
@@ -37,6 +37,7 @@ f_text_sub()
     f_log_info "Substituting text in files"
 
     find "${_build_dir}" -type f -exec sed -i.bak "s/flightctl\.core/redhat.edge_manager/g" {} \;
+    find "${_build_dir}" -type f -exec sed -i.bak "s/Flight Control/Red Hat Edge Manager/g" {} \;
 
     sed -i.bak "s/Flight Control Collection/Red Hat Edge Manager Collection/g" "${_build_dir}/README.md"
     sed -i.bak "s/flightctl\/core/redhat\/edge_manager/g" "${_build_dir}/galaxy.yml"

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -54,7 +54,6 @@ f_prep()
 
     # Files to copy downstream (relative repo root dir path)
     _file_manifest=(
-        .gitignore
         CHANGELOG.rst
         galaxy.yml
         LICENSE
@@ -66,7 +65,6 @@ f_prep()
 
     # Directories to recursively copy downstream (relative repo root dir path)
     _dir_manifest=(
-        .config
         changelogs
         meta
         plugins
@@ -75,7 +73,6 @@ f_prep()
 
     # Temp build dir
     _tmp_dir=$(mktemp -d)
-    _start_dir="${PWD}"
     _build_dir="${_tmp_dir}/ansible_collections/redhat/edge_manager"
     mkdir -p "${_build_dir}"
 }

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -1,0 +1,220 @@
+#!/bin/bash -eu
+
+# Script to dual-home the upstream and downstream Collection in a single repo
+#
+#   This script will build or test a downstream collection, removing any
+#   upstream components that will not ship in the downstream release
+#
+#   NOTES:
+#       - All functions are prefixed with f_ so it's obvious where they come
+#         from when in use throughout the script
+
+DOWNSTREAM_VERSION="1.0.0"
+KEEP_DOWNSTREAM_TMPDIR="${KEEP_DOWNSTREAM_TMPDIR:-''}"
+INSTALL_DOWNSTREAM_COLLECTION_PATH="${INSTALL_DOWNSTREAM_COLLECTION_PATH:-}"
+_build_dir=""
+
+f_log_info()
+{
+    printf "%s:LOG:INFO: %s\n" "${0}" "${1}"
+}
+
+f_show_help()
+{
+    printf "Usage: downstream.sh [OPTION]\n"
+    printf "\t-s\t\tCreate a temporary downstream release and perform sanity tests.\n"
+    printf "\t-u\t\tCreate a temporary downstream release and perform unit tests.\n"
+    printf "\t-i\t\tCreate a temporary downstream release and perform integration tests.\n"
+    printf "\t-b\t\tBuild the downstream release.\n"
+}
+
+f_text_sub()
+{
+    f_log_info "Substituting text in files"
+
+    find "${_build_dir}" -type f -exec sed -i.bak "s/flightctl\.core/redhat.edge_manager/g" {} \;
+
+    sed -i.bak "s/Flight Control Collection/Red Hat Edge Manager Collection/g" "${_build_dir}/README.md"
+    sed -i.bak "s/flightctl\/core/redhat\/edge_manager/g" "${_build_dir}/galaxy.yml"
+    sed -i.bak "s/flightctl\/core/redhat\/edge_manager/g" "${_build_dir}/README.md"
+    sed -i.bak "s/^version\:.*$/version: ${DOWNSTREAM_VERSION}/" "${_build_dir}/galaxy.yml"
+    sed -i.bak "s/^namespace\:.*$/namespace: redhat/" "${_build_dir}/galaxy.yml"
+    sed -i.bak "s/^name\:.*$/name: edge_manager/" "${_build_dir}/galaxy.yml"
+    sed -i.bak "s/core/edge_manager/g" "${_build_dir}/meta/runtime.yml"
+
+    find "${_build_dir}" -type f -name "*.bak" -delete
+}
+
+f_prep()
+{
+    f_log_info "Creating temporary build directory"
+    # Array of excluded files from downstream build (relative path)
+    _file_exclude=(
+    )
+
+    # Files to copy downstream (relative repo root dir path)
+    _file_manifest=(
+        .gitignore
+        CHANGELOG.rst
+        galaxy.yml
+        LICENSE
+        README.md
+        Makefile
+        requirements.txt
+        tox.ini
+    )
+
+    # Directories to recursively copy downstream (relative repo root dir path)
+    _dir_manifest=(
+        .config
+        changelogs
+        meta
+        plugins
+        tests
+    )
+
+    # Temp build dir
+    _tmp_dir=$(mktemp -d)
+    _start_dir="${PWD}"
+    _build_dir="${_tmp_dir}/ansible_collections/redhat/edge_manager"
+    mkdir -p "${_build_dir}"
+}
+
+f_cleanup()
+{
+    f_log_info "Cleaning up"
+    if [[ -n "${_build_dir}" ]]; then
+        if [[ -z ${KEEP_DOWNSTREAM_TMPDIR} ]]; then
+            if [[ -d ${_build_dir} ]]; then
+                rm -fr "${_build_dir}"
+            fi
+        fi
+    fi
+}
+
+# Exit and handle cleanup processes if needed
+trap f_cleanup EXIT
+
+f_exit()
+{
+    f_cleanup
+    exit "$0"
+}
+
+f_create_collection_dir_structure()
+{
+    f_log_info "Creating collection directory structure"
+    # Create the Collection
+    for f_name in "${_file_manifest[@]}";
+    do
+        cp "./${f_name}" "${_build_dir}/${f_name}"
+    done
+    for d_name in "${_dir_manifest[@]}";
+    do
+        cp -r "./${d_name}" "${_build_dir}/${d_name}"
+    done
+    if [ -n "${_file_exclude:-}" ]; then
+        for exclude_file in "${_file_exclude[@]}";
+        do
+            if [[ -f "${_build_dir}/${exclude_file}" ]]; then
+                rm -f "${_build_dir}/${exclude_file}"
+            fi
+        done
+    fi
+}
+
+f_copy_collection_to_working_dir()
+{
+    f_log_info "Copying built collection to working dir"
+    # Copy the Collection build result into original working dir
+    f_log_info "Copying built collection *.tar.gz into ./"
+    cp "${_build_dir}"/*.tar.gz ./
+    # Install downstream collection into provided path
+    if [[ -n ${INSTALL_DOWNSTREAM_COLLECTION_PATH} ]]; then
+        f_log_info "Installing built collection *.tar.gz into ${INSTALL_DOWNSTREAM_COLLECTION_PATH}"
+        ansible-galaxy collection install -p "${INSTALL_DOWNSTREAM_COLLECTION_PATH}" "${_build_dir}"/*.tar.gz
+    fi
+    rm -f "${_build_dir}"/*.tar.gz
+}
+
+f_common_steps()
+{
+    f_prep
+    f_create_collection_dir_structure
+    f_text_sub
+}
+
+# Run the test sanity scenario
+f_test_sanity_option()
+{
+    f_log_info "Running Sanity Tests"
+    f_common_steps
+    pushd "${_build_dir}" || return
+        make sanity-test
+    popd || return
+    f_cleanup
+}
+
+# Run the test integration
+f_test_integration_option()
+{
+    f_log_info "Running Integration Tests"
+    f_common_steps
+    pushd "${_build_dir}" || return
+        make integration-test
+    popd || return
+    f_cleanup
+}
+
+# Run the test units
+f_test_units_option()
+{
+    f_log_info "Running Unit Tests"
+    f_common_steps
+    pushd "${_build_dir}" || return
+        make unit-test
+    popd || return
+    f_cleanup
+}
+
+# Run the build scenario
+f_build_option()
+{
+    f_log_info "Building Collection"
+    f_common_steps
+    pushd "${_build_dir}" || return
+        ansible-galaxy collection build
+    popd || return
+    f_copy_collection_to_working_dir
+    f_cleanup
+}
+
+# If no options are passed, display usage and exit
+if [[ "${#}" -eq "0" ]]; then
+    f_show_help
+    f_exit 0
+fi
+
+# Handle options
+while getopts ":siub" option
+do
+  case $option in
+    s)
+        f_test_sanity_option
+        ;;
+    i)
+        f_test_integration_option
+        ;;
+    u)
+        f_test_units_option
+        ;;
+    b)
+        f_build_option
+        ;;
+    *)
+        printf "ERROR: Unimplemented option chosen.\n"
+        f_show_help
+        f_exit 1
+        ;;
+  esac
+done

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.7.0
+version: 0.7.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -51,7 +51,7 @@ dependencies: {}
 repository: https://github.com/flightctl/flightctl-ansible
 
 # The URL to any online docs
-documentation: https://github.com/flightctl/flightctl/blob/main/docs/user/README.md
+documentation: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_device_fleets_with_the_red_hat_edge_manager/index
 
 # The URL to the homepage of the collection/project
 homepage: https://github.com/flightctl/flightctl-ansible

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -71,6 +71,7 @@ build_ignore:
   - ".config"
   - ".ruff*"
   - ".tox*"
+  - "ci/"
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.5.0
+version: 1.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -48,16 +48,16 @@ tags:
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: github.com/flightctl/flightctl-ansible
+repository: https://github.com/flightctl/flightctl-ansible
 
 # The URL to any online docs
 documentation: https://github.com/flightctl/flightctl/blob/main/docs/user/README.md
 
 # The URL to the homepage of the collection/project
-homepage: github.com/flightctl/flightctl-ansible
+homepage: https://github.com/flightctl/flightctl-ansible
 
 # The URL to the collection issue tracker
-issues: github.com/flightctl/flightctl-ansible/issues
+issues: https://github.com/flightctl/flightctl-ansible/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.7.1
+version: 1.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/connection/flightctl_console.py
+++ b/plugins/connection/flightctl_console.py
@@ -70,7 +70,7 @@ options:
 EXAMPLES = r"""
 - name: Run a command in a device using passed vars to setup the connection
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   vars:
     ansible_connection: flightctl.core.flightctl_console
     ansible_remote_tmp: /var/.ansible/tmp # Default ansible tmp dir is readonly in bootc devices
@@ -80,6 +80,7 @@ EXAMPLES = r"""
     # Be aware that the command is executed as root and requires python to be installed on the device
     - name: Run a command in a pod
       ansible.builtin.command: echo "Hello, World!"
+      changed_when: false
 
 - name: Run a command in a device using a static inventory file
   # Example inventory:
@@ -96,6 +97,7 @@ EXAMPLES = r"""
     # Be aware that the command is executed as root and requires python to be installed on the device
     - name: Run a command in a device
       ansible.builtin.command: echo "Hello, World!"
+      changed_when: false
 """
 
 

--- a/plugins/inventory/flightctl.py
+++ b/plugins/inventory/flightctl.py
@@ -369,7 +369,7 @@ def _get_data(
                 limit=limit
             )
         except Exception as e:
-            raise FlightctlApiException(f"Error retrieving data from FlightCTL API: {e}") from e
+            raise FlightctlApiException(f"Error retrieving data from Flight Control API: {e}") from e
         records: Sequence[T] = response.items
         all_records.extend(records)
         metadata = response.to_dict().get('metadata', {})

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -411,7 +411,7 @@ class FlightctlAPIModule(FlightctlModule):
 
                 expected_type = ConditionType.APPROVED if input.approved else ConditionType.DENIED
 
-                # Idempotency of certificate approval/denial is no longer handled in FlightCTL.
+                # Idempotency of certificate approval/denial is no longer handled in Flight Control.
                 # This logic will be enforced within the Ansible collection instead.
 
                 if any(cond.type == expected_type for cond in csr.status.conditions):  # Check if the condition already exists

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+  python_requires: '>=3.9'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a script for building and testing downstream Ansible collections, supporting build, sanity, unit, and integration test operations.
  - Added downstream testing phases to continuous integration workflows for unit, sanity, and integration tests.
  - Added configuration for Python version requirements in tests.

- **Documentation**
  - Added detailed instructions for publishing to Ansible Galaxy and Automation Hub.
  - Updated changelog and configuration formatting.
  - Updated README with compatibility requirements and usage section improvements.
  - Added a new release entry for version 1.0.0 with support for Flight Control API v0.7.1.

- **Chores**
  - Updated collection metadata URLs to fully qualified links.
  - Renamed and reorganized CI jobs for clearer upstream/downstream separation.

- **Bug Fixes**
  - Corrected example playbook boolean values and task change reporting in connection plugin documentation.
  - Standardized error message text to use "Flight Control API" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->