### PR TITLE
EDM-1399: Flight Control Console Connection Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,21 @@ unit-test:
 integration-test: write-integration-config
 	ansible-test integration --docker --diff --color --python $(PYTHON_VERSION) -v $(?TEST_ARGS)
 
+# Running an integration test for the connection plugin is possible, but currently marked as
+# unsupported in ansible-test and thus does not run in CI.
+#
+# To run the integration test locally, requirements are a running flightctl server as well as an
+# onboarded and connected device.  The ansible_flightctl_device_name in the test must be manually set
+# to the name of the device you want to test against.
+integration-test-connection: write-integration-config
+	ansible-test integration connection_flightctl_console \
+		--docker --diff --color --python $(PYTHON_VERSION) --allow-unsupported -v
+
 sanity-test:
 	ansible-test sanity --docker -v --color --python $(PYTHON_VERSION) $(?TEST_ARGS)
 
 write-integration-config:
-	@token="$(shell grep 'token:' ~/.config/flightctl/client.yaml | awk '{print $$2}')"; \
-	service_addr="$(shell grep 'server:' ~/.config/flightctl/client.yaml | awk '{print $$2}')"; \
+	@token="$$(grep '^  token:' ~/.config/flightctl/client.yaml | awk '{print $$2}')"; \
+	service_addr="$$(awk '/^service:/,/^  server:/' ~/.config/flightctl/client.yaml | grep 'server:' | awk '{print $$2}')"; \
 	echo "flightctl_token: $$token" > ./tests/integration/integration_config.yml; \
 	echo "flightctl_host: $$service_addr" >> ./tests/integration/integration_config.yml;

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ integration-test: write-integration-config
 # unsupported in ansible-test and thus does not run in CI.
 #
 # To run the integration test locally, requirements are a running flightctl server as well as an
-# onboarded and connected device.  The ansible_flightctl_device_name in the test must be manually set
-# to the name of the device you want to test against.
+# onboarded and connected device.  The ansible_flightctl_device_name in the test (test_connection.yml)
+# must be manually set to the name of the device you want to test against.
 integration-test-connection: write-integration-config
 	ansible-test integration connection_flightctl_console \
 		--docker --diff --color --python $(PYTHON_VERSION) --allow-unsupported -v

--- a/changelogs/fragments/add-flightctl-console-connection-plugin.yml
+++ b/changelogs/fragments/add-flightctl-console-connection-plugin.yml
@@ -1,0 +1,4 @@
+major_changes:
+  - Added flight control console connection plugin
+bugfixes:
+  - auth documentation - fixed env var names to align with module usage

--- a/demo/README.md
+++ b/demo/README.md
@@ -102,6 +102,6 @@ Requires a running flightctl server and an onboarded and currently running devic
 To run with a static inventory file, update demo/connection/inventory to have the correct ansible_flightctl_device_name for your running device.  Update the ansible_flightctl_config_file to point towards an updated client config file or configure the other options like host, token, ca_path as needed.
 
 After configuring run:
-```
+```bash
 ansible-playbook demo/connection/flightctl_connection.yml -i demo/connection/inventory
 ```

--- a/demo/README.md
+++ b/demo/README.md
@@ -94,3 +94,14 @@ ansible-playbook demo/create.yml \
 ansible-playbook demo/create.yml \
     --extra-vars "flightctl_config_file='~/.config/flightctl/client.yaml'" \
     --extra-vars "flightctl_validate_certs=True"
+
+## Connection Plugin
+
+Requires a running flightctl server and an onboarded and currently running device.
+
+To run with a static inventory file, update demo/connection/inventory to have the correct ansible_flightctl_device_name for your running device.  Update the ansible_flightctl_config_file to point towards an updated client config file or configure the other options like host, token, ca_path as needed.
+
+After configuring run:
+```
+ansible-playbook demo/connection/flightctl_connection.yml -i demo/connection/inventory
+```

--- a/demo/connection/flightctl_connection.yml
+++ b/demo/connection/flightctl_connection.yml
@@ -1,0 +1,20 @@
+---
+- name: Test Flight Control connection plugin
+  hosts: flightctl
+  gather_facts: false
+  tasks:
+    - name: Fetch the currently running agent version from the device
+      ansible.builtin.command: /usr/bin/flightctl-agent version
+      register: version
+
+    - name: Display the version
+      debug:
+        var: version
+
+    - name: Copy config.yaml to remote machine
+      ansible.builtin.command: /usr/bin/flightctl-agent system-info
+      register: info
+
+    - name: Display the system-info
+      debug:
+        var: info

--- a/demo/connection/flightctl_connection.yml
+++ b/demo/connection/flightctl_connection.yml
@@ -11,7 +11,7 @@
       debug:
         var: version
 
-    - name: Copy config.yaml to remote machine
+    - name: Fetch system information from remote machine
       ansible.builtin.command: /usr/bin/flightctl-agent system-info
       register: info
 

--- a/demo/connection/inventory
+++ b/demo/connection/inventory
@@ -3,9 +3,9 @@ flightctl:
     example-device-1:
       ansible_connection: flightctl.core.flightctl_console
       ansible_remote_tmp: /var/.ansible/tmp
-      ansible_flightctl_device_name: 58use3ehgph4n8ljloma9lhe6idrirqk7nvu9pif007p5b5k1qp0
+      ansible_flightctl_device_name:
       ansible_flightctl_config_file: ~/.config/flightctl/client.yaml
-      #ansible_flightctl_host:
-      #ansible_flightctl_token:
-      #ansible_flightctl_ca_path:
-      #ansible_flightctl_validate_certs:
+      # ansible_flightctl_host:
+      # ansible_flightctl_token:
+      # ansible_flightctl_ca_path:
+      # ansible_flightctl_validate_certs:

--- a/demo/connection/inventory
+++ b/demo/connection/inventory
@@ -1,0 +1,11 @@
+flightctl:
+  hosts:
+    example-device-1:
+      ansible_connection: flightctl.core.flightctl_console
+      ansible_remote_tmp: /var/.ansible/tmp
+      ansible_flightctl_device_name: 58use3ehgph4n8ljloma9lhe6idrirqk7nvu9pif007p5b5k1qp0
+      ansible_flightctl_config_file: ~/.config/flightctl/client.yaml
+      #ansible_flightctl_host:
+      #ansible_flightctl_token:
+      #ansible_flightctl_ca_path:
+      #ansible_flightctl_validate_certs:

--- a/plugins/connection/flightctl_console.py
+++ b/plugins/connection/flightctl_console.py
@@ -1,0 +1,462 @@
+# coding: utf-8 -*-
+
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+name: flightctl_console
+short_description: Connect to Flight Control managed devices
+description:
+  - This connection plugin allows Ansible to connect to managed Flight Control devices through the API's console endpoint.
+  - It uses WebSockets to establish a persistent connection, which is maintained for the duration of the Ansible playbook run.
+author:
+  - "Dakota Crowder (@dakcrowder)"
+version_added: "0.7.0"
+options:
+  flightctl_device_name:
+    description: The Flight Control device name identifier
+    required: True
+    type: str
+    vars:
+      - name: ansible_flightctl_device_name
+    env:
+      - name: FLIGHTCTL_DEVICE_NAME
+  flightctl_config_file:
+    description: Path to the config file. If value not set, will try environment variable C(FLIGHTCTL_CONFIG_FILE).
+    type: path
+    vars:
+      - name: ansible_flightctl_config_file
+    env:
+      - name: FLIGHTCTL_CONFIG_FILE
+  flightctl_host:
+    description: URL to Flight Control server. If value not set, will try environment variable C(FLIGHTCTL_HOST).
+    type: str
+    vars:
+      - name: ansible_flightctl_host
+    env:
+      - name: FLIGHTCTL_HOST
+  flightctl_token:
+    description:
+    - The Flight Control API token to use. This value can be in one of two formats.
+    - If value not set, will try environment variable C(FLIGHTCTL_TOKEN)
+    type: str
+    vars:
+      - name: ansible_flightctl_token
+    env:
+      - name: FLIGHTCTL_TOKEN
+  flightctl_validate_certs:
+    description:
+    - Whether to allow insecure connections to Flight Control service. If C(false), SSL certificates will not be validated.
+    - This should only be used on personally controlled sites using self-signed certificates.
+    - If value not set, will try environment variable C(FLIGHTCTL_VERIFY_SSL)
+    type: bool
+    vars:
+      - name: ansible_flightctl_validate_certs
+    env:
+      - name: FLIGHTCTL_VERIFY_SSL
+  flightctl_ca_path:
+    description: Path to a CA cert file to use when making requests. If value not set, will try environment variable C(FLIGHTCTL_CA_PATH).
+    type: path
+    vars:
+      - name: ansible_flightctl_ca_path
+    env:
+      - name: FLIGHTCTL_CA_PATH
+'''
+
+
+EXAMPLES = r"""
+- name: Run a command in a device using passed vars to setup the connection
+  hosts: localhost
+  gather_facts: no
+  vars:
+    ansible_connection: flightctl.core.flightctl_console
+    ansible_remote_tmp: /var/.ansible/tmp # Default ansible tmp dir is readonly in bootc devices
+    ansible_kubectl_pod: my-device-name
+    ansible_flightctl_config_file: ~/.config/flightctl/client.yaml
+  tasks:
+    # Be aware that the command is executed as root and requires python to be installed on the device
+    - name: Run a command in a pod
+      ansible.builtin.command: echo "Hello, World!"
+
+- name: Run a command in a device using a static inventory file
+  # Example inventory:
+  # flightctl:
+  #   hosts:
+  #     example-device-1:
+  #       ansible_connection: flightctl.core.flightctl_console
+  #       ansible_remote_tmp: /var/.ansible/tmp # Default ansible tmp dir is readonly in bootc devices
+  #       ansible_flightctl_device_name: my-device-name
+  #       ansible_flightctl_config_file: ~/.config/flightctl/client.yaml
+  hosts: flightctl
+  gather_facts: false
+  tasks:
+    # Be aware that the command is executed as root and requires python to be installed on the device
+    - name: Run a command in a device
+      ansible.builtin.command: echo "Hello, World!"
+"""
+
+
+import asyncio
+import base64
+import json
+import os
+import re
+import ssl
+import urllib.parse
+from contextlib import asynccontextmanager
+
+try:
+    import websockets
+    from websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
+except ImportError as imp_exc:
+    WEBSOCKETS_IMPORT_ERROR = imp_exc
+else:
+    WEBSOCKETS_IMPORT_ERROR = None
+
+from ansible.plugins.connection import ConnectionBase
+from ansible.errors import AnsibleConnectionFailure
+from ..module_utils.config_loader import ConfigLoader
+
+
+CMD_END_MARKER = "__ANSIBLE_CMD_END__"
+
+
+class Connection(ConnectionBase):
+    """Flight Control connection plugin."""
+
+    # ConnectionBase attributes
+    transport = 'flightctl_console'
+    has_persistent_connections = True
+    has_tty = False
+
+    # Required params
+    host_url = None
+    device_name = None
+
+    # Optional params
+    token = None
+    validate_certs = None
+    ca_path = None
+    ca_data = None
+
+    # Config file representation
+    config_file = None
+
+    def __init__(self, *args, **kwargs):
+        if WEBSOCKETS_IMPORT_ERROR:
+            raise WEBSOCKETS_IMPORT_ERROR
+
+        super(Connection, self).__init__(*args, **kwargs)
+        self._loop = None
+        self._ws = None
+
+    def _get_param(self, option_name, env_var, config_attr=None):
+        """Get a parameter value from various sources: options, environment variables, or config file."""
+        # 1. Check get_option
+        value = self.get_option(option_name)
+        if value is not None:
+            return value
+
+        # 2. Check environment variable
+        value = os.getenv(env_var)
+        if value is not None:
+            return value
+
+        # 3. Check loaded config file
+        if config_attr and self.config_file:
+            value = getattr(self.config_file, config_attr, None)
+            if value is not None:
+                return value
+
+        # 4. Return None if not found
+        return None
+
+    def _set_device_name(self):
+        self.device_name = self._get_param('flightctl_device_name', 'FLIGHTCTL_DEVICE_NAME')
+        if not self.device_name:
+            raise AnsibleConnectionFailure("flightctl_device_name must be specified")
+
+    def _set_host_url(self):
+        self.host_url = self._get_param('flightctl_host', 'FLIGHTCTL_HOST', 'host')
+        if not self.host_url:
+            raise AnsibleConnectionFailure("flightctl_host must be specified")
+
+    def _set_token(self):
+        self.token = self._get_param('flightctl_token', 'FLIGHTCTL_TOKEN', 'token')
+
+    def _set_validate_certs(self):
+        validate_certs_opt = self.get_option('flightctl_validate_certs')
+        validate_certs_env = os.getenv('FLIGHTCTL_VERIFY_SSL')
+        validate_certs_cfg = getattr(self.config_file, 'verify_ssl', None)
+
+        if validate_certs_opt is not None:
+            self.validate_certs = validate_certs_opt
+        elif validate_certs_env is not None:
+            # Environment variables are strings, convert to bool
+            self.validate_certs = validate_certs_env.lower() == 'true'
+        elif validate_certs_cfg is not None:
+            self.validate_certs = validate_certs_cfg
+        else:
+            self.validate_certs = True
+
+    def _set_ca_cert(self):
+        self.ca_path = self._get_param('flightctl_ca_path', 'FLIGHTCTL_CA_PATH')
+
+        if self.ca_path:
+            return
+
+        # ca_data is only loaded from config file, not env or options
+        encoded_ca_data = getattr(self.config_file, 'ca_data', None)
+        if encoded_ca_data:
+            try:
+                self.ca_data = base64.b64decode(encoded_ca_data).decode('utf-8')
+            except (base64.binascii.Error, UnicodeDecodeError) as e:
+                raise AnsibleConnectionFailure("ca_data is invalid")
+
+    def _set_connection_params(self):
+        """Set connection parameters from passed configuration."""
+        # Load config file if provided
+        config_file_path = self.get_option('flightctl_config_file') or os.getenv('FLIGHTCTL_CONFIG_FILE')
+        if config_file_path and not os.path.exists(config_file_path):
+            raise AnsibleConnectionFailure(f"Config file {config_file_path} does not exist")
+        if config_file_path:
+            self.config_file = ConfigLoader(config_file=config_file_path)
+
+        self._set_device_name()
+        self._set_host_url()
+        self._set_token()
+        self._set_validate_certs()
+        # Note: _set_ca_cert is dependent on validate_certs state
+        # so it should be called after _set_validate_certs
+        self._set_ca_cert() if self.validate_certs else None
+
+        self._display.vvv(
+            f"Connection info:\n"
+            f"  host={self.host_url}\n"
+            f"  device_name={self.device_name}\n"
+            f"  has_token={bool(self.token)}\n"
+            f"  validate_certs={self.validate_certs}"
+        )
+
+    def _get_loop(self):
+        """Get or create the asyncio event loop."""
+        if self._loop is None or self._loop.is_closed():
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+        return self._loop
+
+    def _run_async(self, coro):
+        """Run an async coroutine."""
+        loop = self._get_loop()
+        try:
+            return loop.run_until_complete(coro)
+        except RuntimeError as e:
+            if "already running" in str(e):
+                return asyncio.get_event_loop().run_until_complete(coro)
+            raise
+
+    @asynccontextmanager
+    async def _open_websocket(self):
+        """Context manager to open persistent websocket."""
+        ws_url = self._build_websocket_url()
+        self._display.vvv(f"Connecting to WebSocket URL: {ws_url}")
+
+        headers = {}
+        if self.token:
+            headers['Authorization'] = f"Bearer {self.token}"
+
+        try:
+            ws = await websockets.connect(
+                ws_url,
+                additional_headers=headers,
+                ssl=self._build_ssl_context(),
+                subprotocols=["v5.channel.k8s.io"],
+            )
+            yield ws
+        except Exception as e:
+            raise AnsibleConnectionFailure(f"WebSocket connect failed: {e}")
+
+    def _build_websocket_url(self):
+        """Builds a proper WebSocket URL from host URL."""
+        # Remove any trailing slashes
+        host_url = self.host_url.rstrip('/')
+
+        # Strip the https protocol if present
+        if re.match("^https{0,1}://", host_url):
+            host_url = host_url.split("://", 1)[1]
+
+        metadata = self._build_metadata()
+        encoded_metadata = urllib.parse.quote(metadata)
+
+        return f"wss://{host_url}/ws/v1/devices/{self.device_name}/console?metadata={encoded_metadata}"
+
+    def _build_ssl_context(self):
+        """Build SSL context for the WebSocket connection."""
+        if self.validate_certs:
+            if self.ca_path:
+                return ssl.create_default_context(cafile=self.ca_path)
+            elif self.ca_data:
+                return ssl.create_default_context(cadata=self.ca_data)
+            else:
+                return ssl.create_default_context()
+        else:
+            return ssl._create_unverified_context()
+
+    def _connect(self):
+        """Open persistent websocket connection"""
+        self._display.vvv("Opening persistent WebSocket connection")
+        # Set connection parameters
+        self._set_connection_params()
+        # Establish and cache websocket
+        self._ws = self._run_async(self._open_websocket().__aenter__())
+        return self
+
+    def _build_metadata(self):
+        """Build the JSON metadata payload for a command."""
+        metadata = {
+            "tty": False,
+            "command": {
+                "command": "",
+                "args": [],
+            },
+        }
+        return json.dumps(metadata)
+
+    def exec_command(self, cmd, in_data=None, sudoable=False):
+        """Run a bash command over the persistent websocket."""
+        if in_data:
+            raise AnsibleConnectionFailure("Pipelining not supported")
+
+        if not self._ws:
+            self._connect()
+
+        try:
+            stdout, stderr = self._run_async(self._send_command(cmd))
+            return 0, stdout.encode(), stderr.encode()
+        except Exception as e:
+            raise AnsibleConnectionFailure(f"exec_command failed: {e}")
+
+    async def _send_command(self, cmd):
+        """Send a command over the WebSocket and receive output/error streams.
+
+        This method implements communication against the v5.channel.k8s.io subprotocol.
+
+        The subprotocol is a simple framing protocol. Each message is prefixed with a single byte
+        indicating the channel number (0, 1, or 2) followed by the message content. The message
+        content is a UTF-8 encoded string. The channel numbers are by convention defined to match
+        the POSIX file-descriptors assigned to STDIN, STDOUT, and STDERR (0, 1, and 2).
+
+        Commands are sent on channel 0 (STDIN) and the output is received on channel 1 (STDOUT).
+        Any error output is received on channel 2 (STDERR). Channel 3 indicates a remote error.
+
+        Sent commands are terminated with a special marker (CMD_END_MARKER) echoed to STDOUT
+        to indicate the end of the command output.
+
+        Args:
+            cmd: The command string to execute on the remote device.
+
+        Returns:
+            A tuple containing the captured stdout and stderr as strings.
+
+        Raises:
+            AnsibleConnectionFailure: If the WebSocket is not connected or if a remote stream error occurs.
+            Exception: For other unexpected errors during WebSocket communication.
+        """
+        if not self._ws:
+            raise AnsibleConnectionFailure("WebSocket is not connected.")
+
+        full_cmd = cmd + f'\necho {CMD_END_MARKER}\n'
+        try:
+            await self._ws.send(b'\x00' + full_cmd.encode())
+
+            output = ""
+            errOutput = ""
+            while True:
+                msg = await self._ws.recv()
+                channel = msg[0]
+                content = msg[1:].decode(errors="ignore")
+
+                if channel == 1:
+                    output += content
+                    # Only break if we're looking for CMD_END_MARKER
+                    if CMD_END_MARKER in content:
+                        break
+                elif channel == 2:
+                    errOutput += content
+                elif channel == 3:
+                    raise Exception("Stream error occurred: " + content)
+
+            return output.replace(CMD_END_MARKER, "").strip(), errOutput.strip()
+        except (ConnectionClosedOK, ConnectionClosedError) as e:
+            self._ws = None  # Clear the websocket reference since it's no longer usable
+            raise AnsibleConnectionFailure(f"WebSocket is not connected: {str(e)}")
+        except Exception as e:
+            # Handle any other exceptions
+            raise AnsibleConnectionFailure(f"Error during command execution: {str(e)}")
+
+    def put_file(self, in_path, out_path):
+        """Upload a file by streaming its contents over stdin."""
+        try:
+            # Read file contents and encode in base64
+            with open(in_path, 'rb') as f:
+                content = f.read()
+
+            b64content = base64.b64encode(content).decode()
+
+            # Create a command that will decode the base64 data and write to the output file
+            cmd = f"mkdir -p $(dirname '{out_path}') && cat << 'EOF_ANSIBLE_PUT_FILE' | base64 -d > '{out_path}'\n{b64content}\nEOF_ANSIBLE_PUT_FILE"
+
+            self._display.vvv(f"Copying file to {out_path}")
+
+            # Use the existing _send_command method to execute the file transfer
+            self._run_async(self._send_command(cmd))
+        except Exception as e:
+            raise AnsibleConnectionFailure(f"put_file failed: {str(e)}")
+
+    def fetch_file(self, in_path, out_path):
+        """Download a file from the remote system to the local system."""
+        try:
+            self._display.vvv(f"Fetching file from {in_path} to {out_path}")
+
+            # Read the remote file and encode it as base64
+            cmd = f"cat '{in_path}' 2>/dev/null | base64"
+            stdout, stderr = self._run_async(self._send_command(cmd))
+
+            if stderr:
+                raise AnsibleConnectionFailure(f"Error reading remote file: {stderr}")
+
+            if not stdout:
+                raise AnsibleConnectionFailure(f"Remote file {in_path} not found or is empty")
+
+            # Decode the base64 content
+            try:
+                content = base64.b64decode(stdout)
+            except Exception as e:
+                raise AnsibleConnectionFailure(f"Failed to decode base64 content: {e}")
+
+            # Create the local directory if it doesn't exist
+            local_dir = os.path.dirname(out_path)
+            if not os.path.exists(local_dir):
+                os.makedirs(local_dir)
+
+            # Write the content to the local file
+            with open(out_path, 'wb') as f:
+                f.write(content)
+        except Exception as e:
+            raise AnsibleConnectionFailure(f"fetch_file failed: {str(e)}")
+
+    def reset(self):
+        """Reset the connection to the device."""
+        self._display.vvv("Resetting connection")
+        self.close()
+        self._connect()
+
+    def close(self):
+        """Close persistent websocket if open"""
+        if self._ws:
+            self._run_async(self._ws.close())
+            self._ws = None

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -9,7 +9,7 @@ options:
   flightctl_host:
     description:
     - URL to Flight Control server.
-    - If value not set, will try environment variable C(FLIGHTCTL_HOSTNAME).
+    - If value not set, will try environment variable C(FLIGHTCTL_HOST).
     type: str
   flightctl_username:
     description:
@@ -28,7 +28,7 @@ options:
     description:
     - The Flight Control API token to use.
     - This value can be in one of two formats.
-    - If value not set, will try environment variable C(FLIGHTCTL_API_TOKEN)
+    - If value not set, will try environment variable C(FLIGHTCTL_TOKEN)
     type: str
   flightctl_validate_certs:
     description:

--- a/plugins/module_utils/config_loader.py
+++ b/plugins/module_utils/config_loader.py
@@ -32,6 +32,7 @@ class ConfigLoader:
 
         # Assign token from config if it exists
         # Load from config file if provided
+        config_data = None
         if config_file:
             config_data = self._load_config_file(config_file)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml>=6.0.1
 jsonpatch
 jsonschema
 git+https://github.com/flightctl/flightctl-python-client.git
-websockets
+websockets>=15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml>=6.0.1
 jsonpatch
 jsonschema
 git+https://github.com/flightctl/flightctl-python-client.git
+websockets

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema
 jsonpatch
 git+https://github.com/flightctl/flightctl-python-client.git
+websockets

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema
 jsonpatch
 git+https://github.com/flightctl/flightctl-python-client.git
-websockets
+websockets>=15.0.1

--- a/tests/integration/targets/connection_flightctl_console/aliases
+++ b/tests/integration/targets/connection_flightctl_console/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/connection_flightctl_console/runme.sh
+++ b/tests/integration/targets/connection_flightctl_console/runme.sh
@@ -10,6 +10,6 @@ echo "Running ansible-playbook with args: ${CMD_ARGS[*]}"
 FLIGHTCTL_HOST=$(grep -oP 'flightctl_host:\s*\K.*' "../../integration_config.yml")
 FLIGHTCTL_TOKEN=$(grep -oP 'flightctl_token:\s*\K.*' "../../integration_config.yml")
 
-ansible-playbook "./test_connection.yml" "$@" -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" "${CMD_ARGS[@]}"
+ansible-playbook "./test_connection.yml" -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" "${CMD_ARGS[@]}"
 
 echo "DONE"

--- a/tests/integration/targets/connection_flightctl_console/runme.sh
+++ b/tests/integration/targets/connection_flightctl_console/runme.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CMD_ARGS=("$@")
+
+echo "Running ansible-playbook with args: ${CMD_ARGS[*]}"
+
+# Parse flightctl_host from the integration_config.yml file and pass it to the paybook
+FLIGHTCTL_HOST=$(grep -oP 'flightctl_host:\s*\K.*' "../../integration_config.yml")
+FLIGHTCTL_TOKEN=$(grep -oP 'flightctl_token:\s*\K.*' "../../integration_config.yml")
+
+ansible-playbook "./test_connection.yml" "$@" -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" "${CMD_ARGS[@]}"
+
+echo "DONE"

--- a/tests/integration/targets/connection_flightctl_console/test_connection.yml
+++ b/tests/integration/targets/connection_flightctl_console/test_connection.yml
@@ -1,0 +1,70 @@
+---
+- name: Test Flight Control connection plugin
+  hosts: localhost
+  gather_facts: false
+  vars:
+    ansible_connection: flightctl.core.flightctl_console
+    ansible_remote_tmp: /var/.ansible/tmp
+    ansible_flightctl_device_name: 58use3ehgph4n8ljloma9lhe6idrirqk7nvu9pif007p5b5k1qp0
+    ansible_flightctl_token: "{{ flightctl_token | default(omit)}}"
+    ansible_flightctl_host: "{{ flightctl_host }}"
+    ansible_flightctl_validate_certs: false
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Test ping connection
+      ansible.builtin.ping:
+      register: ping_result
+
+    - name: Assert that the ping was successful
+      ansible.builtin.assert:
+        that:
+          - ping_result.ping == "pong"
+
+    - name: Run a simple command over the WebSocket connection
+      ansible.builtin.command: /usr/bin/flightctl-agent version
+      register: result
+
+    - name: Assert that the command output contains expected text
+      ansible.builtin.assert:
+        that:
+          - "'Flightctl Agent Version:' in result.stdout"
+
+    - name: Test reset connection
+      ansible.builtin.meta: reset_connection
+
+    - name: Test file transfer to device
+      ansible.builtin.copy:
+        content: "This is a test file for FlightCtl connection plugin"
+        dest: "/tmp/test-flightctl-file.txt"
+        mode: '0644'
+      register: copy_result
+
+    - name: Verify file copy succeeded
+      ansible.builtin.command: cat /tmp/test-flightctl-file.txt
+      register: cat_result
+
+    - name: Assert that the file copy was successful
+      ansible.builtin.assert:
+        that:
+          - "'This is a test file for FlightCtl connection plugin' in cat_result.stdout"
+
+    - name: Fetch the file back
+      ansible.builtin.fetch:
+        src: /tmp/test-flightctl-file.txt
+        dest: "{{ playbook_dir }}/fetched-file.txt"
+        flat: true
+
+    - name: Assert that the fetched file contains expected text
+      ansible.builtin.assert:
+        that:
+          - "'This is a test file for FlightCtl connection plugin' in lookup('file', playbook_dir + '/fetched-file.txt')"
+
+    - name: Clean up test file
+      ansible.builtin.file:
+        path: /tmp/test-flightctl-file.txt
+        state: absent
+
+    - name: Clean up fetched file
+      ansible.builtin.file:
+        path: "{{ playbook_dir }}/fetched-file.txt"
+        state: absent

--- a/tests/integration/targets/connection_flightctl_console/test_connection.yml
+++ b/tests/integration/targets/connection_flightctl_console/test_connection.yml
@@ -5,7 +5,7 @@
   vars:
     ansible_connection: flightctl.core.flightctl_console
     ansible_remote_tmp: /var/.ansible/tmp
-    ansible_flightctl_device_name: r3rh1eoh5vbf747catchhv930pf17kskb0ee1t7ioaqsuk7bm020
+    ansible_flightctl_device_name: gb3uh5qn7d6r6og410toti8pinhs860t5ggb6npafikqrsl7nlng
     ansible_flightctl_token: "{{ flightctl_token | default(omit)}}"
     ansible_flightctl_host: "{{ flightctl_host }}"
     ansible_flightctl_validate_certs: false

--- a/tests/integration/targets/connection_flightctl_console/test_connection.yml
+++ b/tests/integration/targets/connection_flightctl_console/test_connection.yml
@@ -5,7 +5,7 @@
   vars:
     ansible_connection: flightctl.core.flightctl_console
     ansible_remote_tmp: /var/.ansible/tmp
-    ansible_flightctl_device_name: 58use3ehgph4n8ljloma9lhe6idrirqk7nvu9pif007p5b5k1qp0
+    ansible_flightctl_device_name: r3rh1eoh5vbf747catchhv930pf17kskb0ee1t7ioaqsuk7bm020
     ansible_flightctl_token: "{{ flightctl_token | default(omit)}}"
     ansible_flightctl_host: "{{ flightctl_host }}"
     ansible_flightctl_validate_certs: false

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,0 @@
-def pytest_configure(config):
-    config.option.asyncio_mode = "auto"
-    # Setting asyncio_default_fixture_loop_scope prevents many
-    # warning logs in the test runner
-    config._inicache["asyncio_default_fixture_loop_scope"] = "function"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,5 @@
+def pytest_configure(config):
+    config.option.asyncio_mode = "auto"
+    # Setting asyncio_default_fixture_loop_scope prevents many
+    # warning logs in the test runner
+    config._inicache["asyncio_default_fixture_loop_scope"] = "function"

--- a/tests/unit/plugins/connection/test_flightctl_console.py
+++ b/tests/unit/plugins/connection/test_flightctl_console.py
@@ -362,6 +362,8 @@ def test_close(mock_conn):
     """Test that close method properly closes the websocket."""
     mock_ws = AsyncMock()
     mock_conn._ws = mock_ws
+    mock_ws_cm = AsyncMock()
+    mock_conn._ws_cm = mock_ws_cm
 
     mock_conn.close()
 
@@ -369,5 +371,6 @@ def test_close(mock_conn):
 
     # Instead of comparing coroutine objects directly, verify that
     # close() was called on the websocket
-    mock_ws.close.assert_called_once()
+    mock_ws_cm.__aexit__.assert_called_once()
     assert mock_conn._ws is None
+    assert mock_conn._ws_cm is None

--- a/tests/unit/plugins/connection/test_flightctl_console.py
+++ b/tests/unit/plugins/connection/test_flightctl_console.py
@@ -1,0 +1,367 @@
+# coding: utf-8 -*-
+
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import asyncio
+import base64
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from ansible.errors import AnsibleConnectionFailure
+
+from plugins.connection.flightctl_console import Connection, CMD_END_MARKER
+
+
+class MockConfigLoader:
+    def __init__(self):
+        self.host = None
+        self.token = None
+        self.verify_ssl = None
+        self.ca_data = None
+
+
+ConnectionClosedOK = type('ConnectionClosedOK', (Exception,), {})
+ConnectionClosedError = type('ConnectionClosedError', (Exception,), {})
+
+
+@pytest.fixture(autouse=True)
+def setup_module_patches(monkeypatch):
+    """Setup mocks for the tests."""
+    # Mock ConfigLoader
+    monkeypatch.setattr('plugins.module_utils.config_loader.ConfigLoader', MockConfigLoader)
+
+    # Mock websockets with proper exception classes
+    mock_websockets = MagicMock()
+    mock_websockets.ConnectionClosedOK = ConnectionClosedOK
+    mock_websockets.ConnectionClosedError = ConnectionClosedError
+    monkeypatch.setattr('websockets.connect', AsyncMock())
+
+    # Make the mocked module available for tests
+    monkeypatch.setattr('plugins.connection.flightctl_console.websockets', mock_websockets)
+    monkeypatch.setattr('plugins.connection.flightctl_console.ConnectionClosedOK', ConnectionClosedOK)
+    monkeypatch.setattr('plugins.connection.flightctl_console.ConnectionClosedError', ConnectionClosedError)
+
+    yield
+
+
+@pytest.fixture
+def mock_conn():
+    """Return a mocked connection object."""
+    conn = Connection(MagicMock(), MagicMock(), MagicMock())
+    conn._display = MagicMock()
+
+    # Create and use a mock event loop
+    mock_loop = asyncio.new_event_loop()
+    conn._get_loop = MagicMock(return_value=mock_loop)
+    conn._run_async = MagicMock()
+    conn._run_async.side_effect = mock_loop.run_until_complete
+
+    return conn
+
+
+def set_options(conn, options):
+    """Set options for a connection object."""
+    conn._options = options.copy()
+    # Create the get_option method that draws from _options
+    conn.get_option = conn._options.get
+
+
+@pytest.mark.parametrize("opt_val, env_val, cfg_val, expected", [
+    (True, None, None, True),
+    (False, None, None, False),
+    (None, 'true', None, True),
+    (None, 'false', None, False),
+    (None, None, True, True),
+    (None, None, False, False),
+])
+def test_set_validate_certs(mock_conn, monkeypatch, opt_val, env_val, cfg_val, expected):
+    """Test _set_validate_certs with various inputs."""
+    # Setup options
+    set_options(mock_conn, {'flightctl_validate_certs': opt_val})
+
+    # Setup config file if needed
+    if cfg_val is not None:
+        mock_conn.config_file = MockConfigLoader()
+        mock_conn.config_file.verify_ssl = cfg_val
+
+    # Setup environment if needed
+    if env_val is not None:
+        monkeypatch.setenv('FLIGHTCTL_VERIFY_SSL', env_val)
+    else:
+        monkeypatch.delenv('FLIGHTCTL_VERIFY_SSL', raising=False)
+
+    # Call the method
+    mock_conn._set_validate_certs()
+
+    # Assert the expected value
+    assert mock_conn.validate_certs == expected
+
+
+def test_set_connection_params_basic(mock_conn):
+    """Test that _set_connection_params sets the expected instance attributes."""
+    # Configure options and environment
+    set_options(mock_conn, {
+        'flightctl_device_name': 'test-device',
+        'flightctl_host': 'test-host',
+        'flightctl_token': 'test-token',
+        'flightctl_validate_certs': None
+    })
+
+    # Execute
+    mock_conn._set_connection_params()
+
+    # Verify
+    assert mock_conn.device_name == 'test-device'
+    assert mock_conn.host_url == 'test-host'
+    assert mock_conn.token == 'test-token'
+    assert mock_conn.validate_certs is True
+
+
+def test_set_connection_params_no_device(mock_conn, monkeypatch):
+    """Test that _set_connection_params raises an error when no device name is provided."""
+    set_options(mock_conn, {
+        'flightctl_host': 'test-host',
+    })
+
+    with pytest.raises(AnsibleConnectionFailure, match="flightctl_device_name must be specified"):
+        mock_conn._set_connection_params()
+
+
+def test_set_connection_params_no_host(mock_conn, monkeypatch):
+    """Test that _set_connection_params raises an error when no host is provided."""
+    set_options(mock_conn, {
+        'flightctl_device_name': 'test-device',
+    })
+
+    with pytest.raises(AnsibleConnectionFailure, match="flightctl_host must be specified"):
+        mock_conn._set_connection_params()
+
+
+def test_build_websocket_url(mock_conn):
+    """Test that _build_websocket_url properly constructs the URL."""
+    mock_conn.host_url = "https://api.example.com"
+    mock_conn.device_name = "test-device"
+
+    url = mock_conn._build_websocket_url()
+
+    assert url.startswith("wss://api.example.com/ws/v1/devices/test-device/console?metadata=")
+    assert "command" in url  # Check that metadata is included
+
+
+@pytest.mark.asyncio
+async def test_send_command(mock_conn):
+    """Test the _send_command method."""
+    mock_ws = AsyncMock()
+    mock_conn._ws = mock_ws
+
+    # Configure the mock to return specific messages
+    mock_ws.recv.side_effect = [
+        b'\x01stdout data',
+        b'\x02stderr data',
+        b'\x01' + f'more data\n{CMD_END_MARKER}'.encode()
+    ]
+
+    stdout, stderr = await mock_conn._send_command("test command")
+
+    assert "stdout data" in stdout
+    assert "more data" in stdout
+    assert stderr == "stderr data"
+    assert mock_ws.send.await_count == 1
+    assert mock_ws.recv.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_send_command_websocket_closed(mock_conn):
+    """Test that _send_command raises an exception when websocket is closed."""
+    mock_ws = AsyncMock()
+    mock_conn._ws = mock_ws
+
+    mock_ws.send.side_effect = ConnectionClosedError()
+
+    with pytest.raises(AnsibleConnectionFailure, match="WebSocket is not connected"):
+        await mock_conn._send_command("test command")
+
+
+@pytest.mark.asyncio
+async def test_send_command_no_websocket(mock_conn):
+    """Test that _send_command raises an exception when no websocket is available."""
+    # Ensure there's no websocket
+    mock_conn._ws = None
+
+    with pytest.raises(AnsibleConnectionFailure, match="WebSocket is not connected"):
+        await mock_conn._send_command("test command")
+
+
+def test_exec_command(mock_conn):
+    """Test that exec_command connects if needed and runs the command."""
+    mock_conn._ws = None  # Start with no connection
+    mock_conn._connect = MagicMock(return_value=mock_conn)
+
+    async def mock_send_command(cmd):
+        return f"stdout: {cmd}", f"stderr: {cmd}"
+
+    mock_send_command = AsyncMock(side_effect=mock_send_command)
+    mock_conn._send_command = mock_send_command
+
+    rc, stdout, stderr = mock_conn.exec_command("test command")
+
+    assert mock_conn._connect.called
+    assert mock_send_command.called
+    assert rc == 0
+    assert stdout == b"stdout: test command"
+    assert stderr == b"stderr: test command"
+
+
+def test_exec_command_failure(mock_conn):
+    """Test that exec_command handles errors properly."""
+    mock_conn._ws = AsyncMock()
+
+    # Make _send_command raise an exception
+    async def failing_send_command(cmd):
+        raise Exception("Command execution failed")
+
+    mock_conn._send_command = failing_send_command
+
+    with pytest.raises(AnsibleConnectionFailure, match="exec_command failed: .*"):
+        mock_conn.exec_command("failing command")
+
+
+def test_put_file(mock_conn, tmp_path):
+    """Test that put_file reads the file and sends the appropriate command."""
+    test_file_content = "test content"
+    test_file = tmp_path / "testfile"
+    test_file.write_text(test_file_content)
+    remote_path = "/remote/path/file"
+
+    # Mock _send_command to return a simple success result
+    send_command_mock = AsyncMock(return_value=("", ""))
+    mock_conn._send_command = send_command_mock
+    mock_conn._run_async = MagicMock()
+
+    mock_conn.put_file(str(test_file), remote_path)
+
+    expected_b64_content = base64.b64encode(test_file_content.encode()).decode()
+    expected_cmd = (
+        f"mkdir -p $(dirname '{remote_path}') && cat << 'EOF_ANSIBLE_PUT_FILE' | base64 -d > '{remote_path}'\n"
+        f"{expected_b64_content}\n"
+        "EOF_ANSIBLE_PUT_FILE"
+    )
+
+    assert mock_conn._run_async.called
+
+    # We can't easily check the coroutine contents directly, so check
+    # that _send_command was called with the right arguments
+    send_command_mock.assert_called_once_with(expected_cmd)
+
+
+def test_put_file_failure(mock_conn, tmp_path):
+    """Test that put_file handles failures properly."""
+    mock_conn._ws = AsyncMock()
+
+    # Create a test file
+    test_file = tmp_path / "test_file.txt"
+    test_file.write_text("test content")
+
+    # Make _run_async raise an exception when putting file
+    def failing_run_async(coro):
+        raise Exception("File transfer failed")
+
+    mock_conn._run_async = MagicMock(side_effect=failing_run_async)
+
+    with pytest.raises(AnsibleConnectionFailure, match="put_file failed: .*"):
+        mock_conn.put_file(str(test_file), "/remote/path")
+
+
+def test_fetch_file(mock_conn, tmp_path):
+    """Test that fetch_file gets the file and saves it properly."""
+    test_content = "test remote content"
+    encoded_content = base64.b64encode(test_content.encode()).decode()
+    send_command_mock = AsyncMock(return_value=(encoded_content, ""))
+    mock_conn._send_command = send_command_mock
+
+    # Setup output file path using pytest's tmp_path fixture
+    out_dir = tmp_path / "output_dir"
+    out_file = out_dir / "fetched_file.txt"
+
+    mock_conn.fetch_file("/remote/path", str(out_file))
+
+    send_command_mock.assert_called_once_with("cat '/remote/path' 2>/dev/null | base64")
+
+    assert out_dir.exists()
+    assert out_file.exists()
+    assert out_file.read_text() == test_content
+
+
+def test_fetch_file_failure(mock_conn):
+    """Test that fetch_file handles failures properly."""
+    mock_conn._ws = AsyncMock()
+
+    # Make _run_async raise an exception
+    def failing_run_async(coro):
+        raise Exception("File fetch failed")
+
+    mock_conn._run_async = MagicMock(side_effect=failing_run_async)
+
+    with pytest.raises(AnsibleConnectionFailure, match="fetch_file failed: .*"):
+        mock_conn.fetch_file("/remote/path", "/local/path")
+
+
+def test_fetch_file_not_found(mock_conn):
+    """Test fetch_file when remote file doesn't exist (empty output)."""
+    mock_conn._ws = AsyncMock()
+
+    # Mock send_command to return empty content (file not found)
+    async def mock_send_empty(cmd):
+        return "", ""
+    mock_conn._send_command = mock_send_empty
+
+    with pytest.raises(AnsibleConnectionFailure, match="Remote file .* not found or is empty"):
+        mock_conn.fetch_file("/nonexistent/file", "/local/path")
+
+
+def test_fetch_file_decode_error(mock_conn, monkeypatch):
+    """Test fetch_file when base64 decode fails."""
+    mock_conn._ws = AsyncMock()
+
+    async def mock_send(cmd):
+        return "some-content", ""
+    mock_conn._send_command = mock_send
+
+    # Mock base64.b64decode to raise an error
+    def mock_b64decode(data):
+        raise base64.binascii.Error("Invalid base64-encoded string")
+    monkeypatch.setattr(base64, 'b64decode', mock_b64decode)
+
+    with pytest.raises(AnsibleConnectionFailure, match="Failed to decode base64 content"):
+        mock_conn.fetch_file("/remote/file", "/local/path")
+
+
+def test_reset(mock_conn):
+    """Test that reset method calls close and then connect."""
+    mock_conn._ws = AsyncMock()
+    mock_conn.close = MagicMock()
+    mock_conn._connect = MagicMock(return_value=mock_conn)
+
+    mock_conn.reset()
+
+    mock_conn.close.assert_called_once()
+    mock_conn._connect.assert_called_once()
+
+
+def test_close(mock_conn):
+    """Test that close method properly closes the websocket."""
+    mock_ws = AsyncMock()
+    mock_conn._ws = mock_ws
+
+    mock_conn.close()
+
+    assert mock_conn._run_async.called
+
+    # Instead of comparing coroutine objects directly, verify that
+    # close() was called on the websocket
+    mock_ws.close.assert_called_once()
+    assert mock_conn._ws is None

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,5 @@
 jsonpatch
 jsonschema
 pytest
-pytest-asyncio>=0.26.0
 git+https://github.com/flightctl/flightctl-python-client.git
 websockets>=15.0.1

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,6 @@
 jsonpatch
 jsonschema
 pytest
-pytest-asyncio
+pytest-asyncio>=0.26.0
 git+https://github.com/flightctl/flightctl-python-client.git
-websockets
+websockets>=15.0.1

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,6 @@
 jsonpatch
 jsonschema
 pytest
+pytest-asyncio
 git+https://github.com/flightctl/flightctl-python-client.git
+websockets


### PR DESCRIPTION
Implements a connection plugin so that users can run ansible playbooks/tasks and connect to devices using the console api.  Currently, the plugin establishes a connection and wlil maintain it for a series of commands within a given  task for the lifetime of the Connection class.  I would note that the connection is NOT fully persistent across tasks, so if a user performs many operations (e.g. 3 tasks to copy 3 different files from the device to local) we will connect to the device 3 separate times, but within each task the connection will be re-used.  Full persistence is _possible_ within the ansible ecosystem, but imo poorly documented and should be scheduled as follow up work.

More info on the v5.channel.k8s.io streaming protocol this is implemented against can be found [here](https://kubernetes.io/blog/2024/05/01/cri-streaming-explained/#how-does-the-streaming-actually-work)

We will log a message via `systemd-cat` on the remote device whenever we are invoking a command, which can be later queried like:
```bash
[root@localhost /]# journalctl -t ansible-console
Apr 30 19:28:53 localhost.localdomain ansible-console[7507]: exec_command
Apr 30 19:28:53 localhost.localdomain ansible-console[7513]: fetch_file
Apr 30 19:28:53 localhost.localdomain ansible-console[7517]: exec_command
Apr 30 19:28:56 localhost.localdomain ansible-console[7526]: exec_command
Apr 30 19:28:56 localhost.localdomain ansible-console[7537]: put_file
Apr 30 19:28:56 localhost.localdomain ansible-console[7544]: exec_command
Apr 30 19:28:56 localhost.localdomain ansible-console[7548]: exec_command
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Ansible connection plugin for Flight Control devices, enabling synchronous WebSocket-based connections.
  - Added a sample playbook and inventory files to demonstrate and test the new connection plugin.
  - Provided comprehensive integration and unit tests for the Flight Control connection plugin.
  - Added a Makefile target for running integration tests of the Flight Control connection plugin locally.

- **Bug Fixes**
  - Corrected environment variable names in authentication documentation for better alignment with actual usage.

- **Documentation**
  - Updated README with setup instructions and usage details for the new connection plugin.

- **Chores**
  - Added the `websockets` package as a new dependency in requirements files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->