### PR TITLE
EDM-1486: test  for inventory plugin

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible ansible-lint
+          pip install "ansible-core>=2.16,<2.17" ansible-lint
 
       - name: Run downstream integration tests
         run: |

--- a/demo/inventory/.config/flightctl/flightctl.inventory.yaml
+++ b/demo/inventory/.config/flightctl/flightctl.inventory.yaml
@@ -1,0 +1,16 @@
+---
+plugin: flightctl.core.flightctl
+flightctl_validate_certs: False
+verify_ssl: False
+additional_groups:
+  - name: group0
+    label_selectors:
+      - fleet = 'fleet-00'
+    field_selectors:
+      - metadata.name = 'device-03'
+      - metadata.name in ('device-03', 'device-01')
+  - name: group6
+    field_selectors:
+      - metadata.owner = "Fleet/fleet-06"
+request_timeout: 120
+flightctl_config_file: /home/amalykhi/.config/flightctl/client.yaml

--- a/tests/integration/targets/inventory_flightctl/inventory_doc_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_doc_test.yml
@@ -1,0 +1,22 @@
+---
+- name: Test Flight Control inventory plugin
+  hosts: localhost
+  gather_facts: false
+  vars:
+    required_phrases:
+      - "flightctl.core.flightctl"
+      - "returns ansible inventory"
+      - "flightctl_config_file"
+      - "flightctl-python-client"
+  tasks:
+    - name: Run ansible-doc to get plugin help text
+      ansible.builtin.command: ansible-doc -t inventory flightctl.core.flightctl
+      register: doc_output
+      changed_when: false
+
+    - name: Assert every required phrase is present in ansible-doc output
+      ansible.builtin.assert:
+        that:
+          - "item in (doc_output.stdout | lower)"
+        fail_msg: "Required phrase '{{ item }}' is missing in ansible-doc output"
+      loop: "{{ required_phrases }}"

--- a/tests/integration/targets/inventory_flightctl/inventory_setup_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_setup_test.yml
@@ -1,0 +1,79 @@
+---
+# This playbook provides a comprehensive test suite for the flightctl.core.flightctl inventory plugin.
+# It uses the flightctl_resource module for setup/cleanup and ansible-inventory for testing.
+
+- name: 1. Prepare Test Resources (Idempotent)
+  hosts: localhost
+  gather_facts: false
+  vars:
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit) }}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: false
+  tasks:
+    - block:
+        - name: Ensure test fleets exist
+          flightctl.core.flightctl_resource:
+            <<: *connection_info
+            kind: Fleet
+            name: "{{ item.name }}"
+            resource_definition:
+              metadata:
+                name: "{{ item.name }}"
+              spec:
+                selector:
+                  matchLabels:
+                    fleet: "{{ item.name }}"
+                template:
+                  spec:
+                    os:
+                      image: "{{ item.os_image }}"
+                    config:
+                      # This config is used by the inventory plugin's 'compose' feature.
+                      # It now uses a valid configType to pass schema validation.
+                      - name: ansible-vars
+                        configType: InlineConfigProviderSpec
+                        inline:
+                          - path: /etc/flightctl/ansible_user
+                            content: "core"
+          loop:
+            - { name: 'ansible-integration-test-fleet', os_image: 'quay.io/osbuild/fedora-iot:39' }
+            - { name: 'fleet-dev', os_image: 'quay.io/osbuild/fedora-iot:39' }
+            - { name: 'fleet-test', os_image: 'quay.io/osbuild/fedora-iot:40' }
+            - { name: 'fleet-prod', os_image: 'quay.io/osbuild/fedora-iot:stable' }
+
+        - name: Ensure test devices exist
+          flightctl.core.flightctl_resource:
+            <<: *connection_info
+            kind: Device
+            name: "{{ item.name }}"
+            resource_definition:
+              metadata:
+                name: "{{ item.name }}"
+                labels: "{{ item.labels }}"
+          loop:
+            - { name: 'ansible-integration-test-device', labels: { fleet: 'ansible-integration-test-fleet' } }
+            - { name: 'ansible-integration-test-device-label-1', labels: { machine_type: 'forklift' } }
+            - { name: 'ansible-integration-test-device-label-2', labels: { machine_type: 'forklift' } }
+            - { name: 'device-dev-01', labels: { fleet: 'fleet-dev', arch: 'amd64' } }
+            - { name: 'device-dev-02', labels: { fleet: 'fleet-dev', arch: 'arm64' } }
+            - { name: 'device-test-01', labels: { fleet: 'fleet-test', arch: 'amd64' } }
+            - { name: 'device-unmanaged-01', labels: { location: 'lab' } }
+
+        - name: Wait for FlightCtl to process fleet assignments
+          pause:
+            seconds: 10
+            prompt: "Waiting for FlightCtl to process fleet assignments..."
+
+    # --- Display devices from the inventory ---
+        - name: Create client.yaml
+          no_log: true
+          ansible.builtin.copy:
+            dest: ".config/flightctl/client.yaml"
+            mode: "0600"
+            content: |
+              service:
+                server: "{{ flightctl_host }}"
+                insecureSkipVerify: true
+              authentication:
+                token: "{{ flightctl_token }}"

--- a/tests/integration/targets/inventory_flightctl/inventory_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_test.yml
@@ -1,0 +1,127 @@
+---
+- name: Test Inventory Discovery and Host Groups
+  hosts: localhost
+  gather_facts: false
+  environment:
+    ANSIBLE_INVENTORY_PLUGINS: "{{ playbook_dir }}/../../../../plugins/inventory"
+    PYTHONPATH: "{{ playbook_dir }}/../../../../"
+  tasks:
+    - block:
+        - name: Display all inventory groups for debugging
+          debug:
+            msg: 
+              all_groups: "{{ groups.keys() | list }}"
+              all_hosts: "{{ groups['all'] | default([]) }}"
+
+        - name: Assert all expected devices are in 'all' group
+          assert:
+            that:
+              - "'ansible-integration-test-device' in groups['all']"
+              - "'ansible-integration-test-device-label-1' in groups['all']"
+              - "'ansible-integration-test-device-label-2' in groups['all']"
+              - "'device-dev-01' in groups['all']"
+              - "'device-dev-02' in groups['all']"
+              - "'device-test-01' in groups['all']"
+              - "'device-unmanaged-01' in groups['all']"
+
+        # Test automatic fleet grouping
+        - name: Assert devices in fleet ansible-integration-test
+          assert:
+            that:
+              - groups['ansible_integration_test_fleet'] | default([]) | length == 1
+              - "'ansible-integration-test-device' in groups['ansible_integration_test_fleet']"
+
+        # Test label-based groups
+        - name: Assert forklift machines group
+          assert:
+            that:
+              - "'ansible-integration-test-device-label-1' in groups['forklift_machines'] | default([])"
+              - "'ansible-integration-test-device-label-2' in groups['forklift_machines'] | default([])"
+              - groups['forklift_machines'] | default([]) | length == 2
+
+        - name: Assert architecture groups
+          assert:
+            that:
+              - "'device-dev-01' in groups['amd64_devices'] | default([])"
+              - "'device-test-01' in groups['amd64_devices'] | default([])"
+              - "'device-dev-02' in groups['arm64_devices'] | default([])"
+
+        - name: Assert location groups
+          assert:
+            that:
+              - "'device-unmanaged-01' in groups['lab_devices'] | default([])"
+
+        # Test field selector groups
+        - name: Assert fleet field selector groups
+          assert:
+            that:
+              - "'device-dev-01' in groups['fleet_dev_devices'] | default([])"
+              - "'device-dev-02' in groups['fleet_dev_devices'] | default([])"
+              - "'device-test-01' in groups['fleet_test_devices'] | default([])"
+              - "'ansible-integration-test-device' in groups['integration_test_fleet_devices'] | default([])"
+
+        # Test specific name-based groups
+        - name: Assert test group
+          assert:
+            that:
+              - "'ansible-integration-test-device' in groups['test_group'] | default([])"
+              - groups['test_group'] | default([]) | length == 1
+
+        - name: Assert integration test devices group
+          assert:
+            that:
+              - "'ansible-integration-test-device' in groups['integration_test_devices'] | default([])"
+              - "'ansible-integration-test-device-label-1' in groups['integration_test_devices'] | default([])"
+              - "'ansible-integration-test-device-label-2' in groups['integration_test_devices'] | default([])"
+              - groups['integration_test_devices'] | default([]) | length == 3
+
+        # Test mixed selector groups
+        - name: Assert mixed selector groups
+          assert:
+            that:
+              - "'device-dev-01' in groups['dev_amd64_devices'] | default([])"
+              - "'ansible-integration-test-device-label-1' in groups['forklift_devices_by_name'] | default([])"
+              - "'ansible-integration-test-device-label-2' in groups['forklift_devices_by_name'] | default([])"
+
+        - name: Display final inventory content summary
+          debug:
+            msg:
+              total_groups: "{{ groups.keys() | list | length }}"
+              total_hosts: "{{ groups['all'] | default([]) | length }}"
+              custom_groups: "{{ groups.keys() | list | reject('match', '^(all|ungrouped)$') | list }}"
+
+- name: Clean up Test Inventory Resources
+  hosts: localhost
+  gather_facts: false
+  vars:
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit) }}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_validate_certs: false
+  tasks:
+        - name: Delete test devices
+          flightctl.core.flightctl_resource:
+            <<: *connection_info
+            state: absent
+            kind: Device
+            name: "{{ item }}"
+          loop:
+            - 'ansible-integration-test-device'
+            - 'ansible-integration-test-device-label-1'
+            - 'ansible-integration-test-device-label-2'
+            - 'device-dev-01'
+            - 'device-dev-02'
+            - 'device-test-01'
+            - 'device-unmanaged-01'
+
+        - name: Delete test fleets
+          flightctl.core.flightctl_resource:
+            <<: *connection_info
+            state: absent
+            kind: Fleet
+            name: "{{ item }}"
+          loop:
+            - 'ansible-integration-test-fleet'
+            - 'fleet-dev'
+            - 'fleet-test'
+            - 'fleet-prod'

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CMD_ARGS=("$@")
+
+echo "Running inventory test with args: ${CMD_ARGS[*]}"
+
+# Parse flightctl_host from the integration_config.yml file and pass it to the playbook
+FLIGHTCTL_HOST=$(grep -oP 'flightctl_host:\s*\K.*' "../../integration_config.yml")
+FLIGHTCTL_TOKEN=$(grep -oP 'flightctl_token:\s*\K.*' "../../integration_config.yml")
+
+# Create inventory config directory
+mkdir -p .config/flightctl
+
+# Create inventory configuration file with comprehensive additional groups for testing
+cat > .config/flightctl/inventory.yml <<EOF
+---
+plugin: flightctl.core.flightctl
+verify_ssl: False
+host: ${FLIGHTCTL_HOST}
+token: ${FLIGHTCTL_TOKEN}
+request_timeout: 120
+additional_groups:
+  # Group devices by machine type
+  - name: forklift_machines
+    label_selectors:
+      - machine_type = forklift
+  
+  # Group devices by architecture
+  - name: amd64_devices
+    label_selectors:
+      - arch = amd64
+  
+  - name: arm64_devices
+    label_selectors:
+      - arch = arm64
+  
+  # Group devices by location
+  - name: lab_devices
+    label_selectors:
+      - location = lab
+  
+  # Group devices by fleet using field selectors
+  - name: fleet_dev_devices
+    field_selectors:
+      - metadata.owner = "Fleet/fleet-dev"
+  
+  - name: fleet_test_devices
+    field_selectors:
+      - metadata.owner = "Fleet/fleet-test"
+  
+  - name: fleet_prod_devices
+    field_selectors:
+      - metadata.owner = "Fleet/fleet-prod"
+  
+  - name: integration_test_fleet_devices
+    field_selectors:
+      - metadata.owner = "Fleet/ansible-integration-test-fleet"
+  
+  # Test-specific groups using different selector combinations
+  - name: test_group
+    field_selectors:
+      - metadata.name = 'ansible-integration-test-device'
+  
+  - name: integration_test_devices
+    field_selectors:
+      - metadata.name in ('ansible-integration-test-device', 'ansible-integration-test-device-label-1', 'ansible-integration-test-device-label-2')
+  
+  # Mixed selector groups
+  - name: dev_amd64_devices
+    label_selectors:
+      - fleet = fleet-dev
+      - arch = amd64
+  
+  - name: forklift_devices_by_name
+    label_selectors:
+      - machine_type = forklift
+    field_selectors:
+      - metadata.name in ('ansible-integration-test-device-label-1', 'ansible-integration-test-device-label-2')
+EOF
+
+echo "Step 1: Testing inventory plugin documentation..."
+ansible-playbook ./inventory_doc_test.yml "${CMD_ARGS[@]}"
+
+echo "Step 2: Setting up test resources..."
+ansible-playbook ./inventory_setup_test.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" "${CMD_ARGS[@]}"
+
+# Wait a bit for resources to be fully created
+echo "Waiting for resources to be ready..."
+sleep 5
+
+echo "Step 3: Testing inventory discovery..."
+ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" "${CMD_ARGS[@]}"
+
+echo "DONE"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests for the FlightCtl inventory plugin: documentation validation, idempotent provisioning of fleets/devices, inventory discovery and host-group assertions, cleanup, and an executable helper script to run the full sequence (credentials sourced from integration_config.yml).

* **Chores**
  * Added a demo inventory config demonstrating plugin options, timeouts and custom group selectors.
  * CI adjusted to use ansible-core>=2.16,<2.17 for integration test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->