### PR TITLE
EDM-2124: Remove uneccesary deleting ER on teardown

### DIFF
--- a/tests/integration/targets/flightctl_certificate_management/tasks/enrollment-approval.yml
+++ b/tests/integration/targets/flightctl_certificate_management/tasks/enrollment-approval.yml
@@ -96,15 +96,6 @@
         - idempotency_result.changed == False
 
   always:
-    - name: Delete enrollment request
-      flightctl.core.flightctl_resource:
-        <<: *connection_info
-        kind: EnrollmentRequest
-        name: "{{ enrollment_name }}"
-        state: absent
-      ignore_errors: yes
-
-    # Approving an enrollment request attempts to create a device, clean it up here as well
     - name: Delete test device
       flightctl.core.flightctl_resource:
         <<: *connection_info


### PR DESCRIPTION
FIxing the error in integration test

No need to delete ER
```
TASK [flightctl_certificate_management : Delete enrollment request] ************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed to run module: Failed to perform action: Failed to delete resource: Unable to delete EnrollmentRequest - 13d632d86373caaeda64da4052f957faa742fc7050026748bc79065c8819d1b0: (409)\nReason: Conflict\nHTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Request-Id': 'flightctl-api-74cf749f8-tkq9r/01xTCKCbw8-000801', 'Date': 'Tue, 09 Sep 2025 09:01:55 GMT', 'Content-Length': '205'})\nHTTP response body: api_version='v1alpha1' kind='Status' code=409 message='cannot delete ER \"13d632d86373caaeda64da4052f957faa742fc7050026748bc79065c8819d1b0\": device exists' reason='Conflict' status='Failure'\n"}
...ignoring

TASK [flightctl_certificate_management : Delete test device] *******************
changed: [testhost] => {"changed": true, "result": {"apiVersion": "v1alpha1", "code": 200, "kind": "Status", "message": "", "reason": "OK", "status": "Success"}}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Simplified teardown in the enrollment approval integration test by removing the EnrollmentRequest deletion from the always block; only the test Device is now deleted.
  - Streamlined control flow at test end with fewer teardown steps and no error handling for the removed operation.
  - No changes to test logic or assertions; no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->