### PR TITLE
Update CodeRabbit config: refine action pinning, enforce AI attribution

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -253,7 +253,10 @@ reviews:
         CI/CD review — security AND design:
 
         Security:
-        - Pin actions by full SHA, not tag
+        - GitHub-owned actions (actions/*) use tag refs (e.g., @v4)
+          for readability — do NOT flag these for missing SHA pins.
+          Third-party actions must be pinned by full SHA with a
+          trailing version comment (e.g., @<sha> # v1.2.3).
         - No secrets in logs; mask sensitive outputs
         - Least privilege: minimize GITHUB_TOKEN permissions
         - No pull_request_target with checkout of PR head
@@ -440,9 +443,10 @@ reviews:
       - name: "ai-attribution"
         instructions: |
           If AI tools were used (mentioned in PR or commits), verify
-          Red Hat attribution: Assisted-by or Generated-by trailers.
+          attribution trailers: Assisted-by, Generated-by, or
+          Made-with (e.g., Made-with: Cursor) are acceptable.
           Flag use of Co-Authored-By for AI tools.
-        mode: "warning"
+        mode: "error"
 
 # ── Knowledge base ───────────────────────────────────────────
 knowledge_base:


### PR DESCRIPTION
## Summary

- Refine action-pinning rule: allow tag refs for GitHub-owned actions (`actions/*`), require SHA pins only for third-party actions
- Update `ai-attribution` check: accept `Made-with` trailers (e.g., `Made-with: Cursor`) alongside `Assisted-by` and `Generated-by`
- Escalate `ai-attribution` from warning to error

## Test plan

- [ ] Verify CodeRabbit does not flag `actions/checkout@v4` or similar GitHub-owned action tag refs
- [ ] Verify `ai-attribution` fires at error severity on PRs with `Co-Authored-By` AI trailers

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

**Affected Area**: CI configuration (`.coderabbit.yaml`)

**Changes Made**:
1. Refined GitHub Actions pinning guidance to explicitly allow GitHub-owned `actions/*` entries to use semantic version tag refs (e.g., `@v4`) without requiring full SHA pins, while maintaining SHA-pin enforcement for third-party actions
2. Escalated `ai-attribution` pre-merge check from warning to error severity
3. Extended `ai-attribution` acceptable attribution trailers to include `Assisted-by`, `Generated-by`, and `Made-with` (e.g., `Made-with: Cursor`), while continuing to flag `Co-Authored-By` for AI tools

**Impact Assessment**:
- Changes affect only CodeRabbit automated code review configuration
- No impact on module API surface, shared utilities, plugin behavior, test coverage, or collection metadata (galaxy.yml, meta/runtime.yml)
- No backward-compatibility implications for the Ansible collection itself

<!-- end of auto-generated comment: release notes by coderabbit.ai -->