### PR TITLE
NO-ISSUE: Update ansible-collection to v1.6

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLIGHTCTL_REF: v1.1.1
+  FLIGHTCTL_REF: v1.2.0
 
 jobs:
   integration-tests:
@@ -46,8 +46,8 @@ jobs:
       - name: Start flightctl services
         run: make deploy
 
-      - name: Deploy e2e extras
-        run: make deploy-e2e-extras
+      - name: Start e2e registry
+        run: docker run -d --name e2e-registry --network kind -p 5000:5000 quay.io/flightctl/e2eregistry:2
 
       - name: Checkout collection
         uses: actions/checkout@v4
@@ -100,8 +100,8 @@ jobs:
       - name: Start flightctl services
         run: make deploy
 
-      - name: Deploy e2e extras
-        run: make deploy-e2e-extras
+      - name: Start e2e registry
+        run: docker run -d --name e2e-registry --network kind -p 5000:5000 quay.io/flightctl/e2eregistry:2
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ flightctl collection Release Notes
 
 .. contents:: Topics
 
+v1.6.0
+======
+
+Release Summary
+---------------
+
+Added support for Flight Control API v1.2.
+
+Major Changes
+-------------
+
+- Updated the Ansible collection to support Flight Control API version 1.2.
+
 v1.5.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ A specific version of the collection can be installed by using the `version` key
 ---
 collections:
   - name: flightctl.core
-    version: 1.5.0
+    version: 1.6.0
 ```
 
 or using the ansible-galaxy command as follows
 
 ```shell
-ansible-galaxy collection install flightctl.core:1.5.0
+ansible-galaxy collection install flightctl.core:1.6.0
 ```
 
 Refer to the following for more details.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -135,3 +135,11 @@ releases:
         name: flightctl_image_builder_info
         namespace: ''
     release_date: '2026-04-06'
+  1.6.0:
+    changes:
+      major_changes:
+        - Updated the Ansible collection to support Flight Control API version 1.2.
+      release_summary: Added support for Flight Control API v1.2.
+    fragments:
+      - flightctl_1.6.0_update.yml
+    release_date: '2026-06-22'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.5.0
+version: 1.6.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/flightctl.py
+++ b/plugins/inventory/flightctl.py
@@ -292,6 +292,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         request_timeout = self.get_option('request_timeout') or 120.0
 
+        host = host.rstrip('/')
+        if not host.endswith('/api/v1'):
+            host = f"{host}/api/v1"
+
         config = Configuration(
             host=host,
             access_token=access_token,
@@ -422,10 +426,29 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
 
 # ---------------------- Custom context manager ------------------
+def _set_org_id_query_param(client: ApiClient, organization: str) -> None:
+    """Inject the optional Flight Control org selector as a query parameter."""
+    original_param_serialize = client.param_serialize
+
+    def param_serialize_with_org_id(*args: Any, **kwargs: Any) -> Any:
+        query_params = kwargs.get('query_params')
+        if query_params is None:
+            query_params = []
+            kwargs['query_params'] = query_params
+        if not any(k == 'org_id' for k, _v in query_params):
+            query_params.append(('org_id', organization))
+        return original_param_serialize(*args, **kwargs)
+
+    client.param_serialize = param_serialize_with_org_id
+
+
 @contextmanager
 def flightctl_apis(config: Configuration) -> Generator[tuple[DeviceApi, FleetApi], Any, None]:
     """ Context manager yielding both API clients (device_api, fleet_api) """
     with ApiClient(configuration=config) as client:
+        organization = getattr(config, 'organization', None)
+        if organization:
+            _set_org_id_query_param(client, str(organization))
         yield DeviceApi(client), FleetApi(client)
 
 

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -122,8 +122,12 @@ class FlightctlAPIModule(FlightctlModule):
         if CLIENT_IMPORT_ERROR:
             self.fail_json(msg="Flight Control client import failed", error=str(CLIENT_IMPORT_ERROR))
 
+        host_url = self.url.geturl().rstrip('/')
+        if not host_url.endswith('/api/v1'):
+            host_url = f"{host_url}/api/v1"
+
         client_config = Configuration(
-            host=self.url.geturl(),
+            host=host_url,
             ssl_ca_cert=self.ca_path,
         )
         client_config.verify_ssl = self.verify_ssl
@@ -134,7 +138,7 @@ class FlightctlAPIModule(FlightctlModule):
         self._set_org_id_query_param(self.client)
 
         v1alpha1_config = V1Alpha1Configuration(
-            host=self.url.geturl(),
+            host=host_url,
             ssl_ca_cert=self.ca_path,
         )
         v1alpha1_config.verify_ssl = self.verify_ssl

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml>=6.0.1
 jsonpatch
 jsonschema
 websockets>=15.0.1
-flightctl-client==1.1.0
+flightctl-client==1.2.1

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema
 jsonpatch
-flightctl-client==1.1.0
+flightctl-client==1.2.1
 websockets>=15.0.1

--- a/tests/integration/targets/flightctl_certificate_management/tasks/certificate-signing-approval.yml
+++ b/tests/integration/targets/flightctl_certificate_management/tasks/certificate-signing-approval.yml
@@ -8,6 +8,11 @@
       flightctl_organization: "{{ flightctl_organization | default(omit)}}"
       flightctl_validate_certs: False
   block:
+  - name: Generate CSR with svc- prefixed CN for server-svc signer
+    include_tasks: generate-csr.yml
+    vars:
+      csr_resource_name: "svc-{{ csr_name }}"
+
   - name: Create a csr
     flightctl.core.flightctl_resource:
       <<: *connection_info
@@ -16,8 +21,8 @@
       api_version: flightctl.io/v1beta1
       resource_definition:
         spec:
-          request: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQkJqQ0JyUUlCQURCTE1Va3dSd1lEVlFRREUwQXhNMlEyTXpKa09EWXpOek5qWVdGbFpHRTJOR1JoTkRBMQpNbVk1TlRkbVlXRTNOREptWXpjd05UQXdNalkzTkRoaVl6YzVNRFkxWXpnNE1UbGtNV0l3TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRUhCTUMzME5SSlRKM05XT2xlaTlZV2tCTS9Nem9OREd5TVJLdXpFMC8KY0treVhWSmV4SHEweEluMjJZQ05OM1pETnh4d1c2TGxRZzNpakdudlN0UU9iNkFBTUFvR0NDcUdTTTQ5QkFNQwpBMGdBTUVVQ0lRRFNyeGk2a3JkQ0tjTENoZE1CM3c3SXFtRGxaaFJFR2JITUNFU1ZuNnNzUEFJZ1pMK1FySnR3CjhSK3I0cGlhWXZaa3Ryc2szeUNJdXozaEk3bG9ZbVhQM2Q4PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0=
-          signerName: flightctl.io/enrollment
+          request: "{{ generated_csr_b64 }}"
+          signerName: flightctl.io/server-svc
           usages: ["clientAuth", "CA:false"]
 
   - name: Approve the csr

--- a/tests/integration/targets/flightctl_certificate_management/tasks/certificate-signing-denial.yml
+++ b/tests/integration/targets/flightctl_certificate_management/tasks/certificate-signing-denial.yml
@@ -8,6 +8,11 @@
       flightctl_organization: "{{ flightctl_organization | default(omit)}}"
       flightctl_validate_certs: False
   block:
+  - name: Generate CSR with svc- prefixed CN for server-svc signer
+    include_tasks: generate-csr.yml
+    vars:
+      csr_resource_name: "svc-{{ csr_name }}"
+
   - name: Create a csr
     flightctl.core.flightctl_resource:
       <<: *connection_info
@@ -16,8 +21,8 @@
       api_version: flightctl.io/v1beta1
       resource_definition:
         spec:
-          request: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQkJqQ0JyUUlCQURCTE1Va3dSd1lEVlFRREUwQXhNMlEyTXpKa09EWXpOek5qWVdGbFpHRTJOR1JoTkRBMQpNbVk1TlRkbVlXRTNOREptWXpjd05UQXdNalkzTkRoaVl6YzVNRFkxWXpnNE1UbGtNV0l3TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRUhCTUMzME5SSlRKM05XT2xlaTlZV2tCTS9Nem9OREd5TVJLdXpFMC8KY0treVhWSmV4SHEweEluMjJZQ05OM1pETnh4d1c2TGxRZzNpakdudlN0UU9iNkFBTUFvR0NDcUdTTTQ5QkFNQwpBMGdBTUVVQ0lRRFNyeGk2a3JkQ0tjTENoZE1CM3c3SXFtRGxaaFJFR2JITUNFU1ZuNnNzUEFJZ1pMK1FySnR3CjhSK3I0cGlhWXZaa3Ryc2szeUNJdXozaEk3bG9ZbVhQM2Q4PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0=
-          signerName: flightctl.io/enrollment
+          request: "{{ generated_csr_b64 }}"
+          signerName: flightctl.io/server-svc
           usages: ["clientAuth", "CA:false"]
 
   - name: Deny the csr+

--- a/tests/integration/targets/flightctl_certificate_management/tasks/enrollment-denial.yml
+++ b/tests/integration/targets/flightctl_certificate_management/tasks/enrollment-denial.yml
@@ -8,6 +8,11 @@
       flightctl_organization: "{{ flightctl_organization | default(omit)}}"
       flightctl_validate_certs: False
   block:
+  - name: Generate CSR with matching CN
+    include_tasks: generate-csr.yml
+    vars:
+      csr_resource_name: "{{ enrollment_name }}"
+
   - name: Create an enrollment request
     flightctl.core.flightctl_resource:
       <<: *connection_info
@@ -16,15 +21,7 @@
       api_version: flightctl.io/v1beta1
       resource_definition:
         spec:
-          csr: |
-            -----BEGIN CERTIFICATE REQUEST-----
-            MIIBBjCBrQIBADBLMUkwRwYDVQQDE0AxM2Q2MzJkODYzNzNjYWFlZGE2NGRhNDA1
-            MmY5NTdmYWE3NDJmYzcwNTAwMjY3NDhiYzc5MDY1Yzg4MTlkMWIwMFkwEwYHKoZI
-            zj0CAQYIKoZIzj0DAQcDQgAEHBMC30NRJTJ3NWOlei9YWkBM/MzoNDGyMRKuzE0/
-            cKkyXVJexHq0xIn22YCNN3ZDNxxwW6LlQg3ijGnvStQOb6AAMAoGCCqGSM49BAMC
-            A0gAMEUCIQDSrxi6krdCKcLChdMB3w7IqmDlZhREGbHMCESVn6ssPAIgZL+QrJtw
-            8R+r4piaYvZktrsk3yCIuz3hI7loYmXP3d8=
-            -----END CERTIFICATE REQUEST-----
+          csr: "{{ generated_csr_pem }}"
 
   - name: Deny the enrollment request in check mode
     flightctl.core.flightctl_certificate_management:

--- a/tests/integration/targets/flightctl_certificate_management/tasks/generate-csr.yml
+++ b/tests/integration/targets/flightctl_certificate_management/tasks/generate-csr.yml
@@ -1,0 +1,19 @@
+---
+- name: Generate EC private key
+  ansible.builtin.command:
+    cmd: openssl ecparam -genkey -name prime256v1 -noout
+  register: _privkey
+  changed_when: false
+
+- name: Generate CSR with matching CN
+  ansible.builtin.command:
+    cmd: openssl req -new -key /dev/stdin -subj "/CN={{ csr_resource_name }}"
+  args:
+    stdin: "{{ _privkey.stdout }}"
+  register: _csr_pem
+  changed_when: false
+
+- name: Set CSR facts for use in subsequent tasks
+  ansible.builtin.set_fact:
+    generated_csr_b64: "{{ _csr_pem.stdout | b64encode }}"
+    generated_csr_pem: "{{ _csr_pem.stdout }}"

--- a/tests/integration/targets/flightctl_image_builder/tasks/imagebuild-lifecycle.yml
+++ b/tests/integration/targets/flightctl_image_builder/tasks/imagebuild-lifecycle.yml
@@ -86,11 +86,10 @@
         name: "{{ dest_repo_name }}"
         resource_definition:
           spec:
-            registry: e2e-container-registry.flightctl-e2e.svc.cluster.local:5000
+            registry: e2e-registry:5000
             type: oci
-            scheme: https
+            scheme: http
             accessMode: ReadWrite
-            skipServerVerification: true
       register: dest_repo_result
 
     - name: Assert destination repository was created

--- a/tests/integration/targets/flightctl_image_builder/tasks/imageexport-lifecycle.yml
+++ b/tests/integration/targets/flightctl_image_builder/tasks/imageexport-lifecycle.yml
@@ -87,11 +87,10 @@
         name: "{{ dest_repo_name }}"
         resource_definition:
           spec:
-            registry: e2e-container-registry.flightctl-e2e.svc.cluster.local:5000
+            registry: e2e-registry:5000
             type: oci
-            scheme: https
+            scheme: http
             accessMode: ReadWrite
-            skipServerVerification: true
       register: dest_repo_result
 
     - name: Assert destination repository was created

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -2,4 +2,4 @@ jsonpatch
 jsonschema
 pytest
 websockets>=15.0.1
-flightctl-client==1.1.0
+flightctl-client==1.2.1


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR releases **collection version 1.6.0** and updates the underlying **Flight Control client dependency** to support **Flight Control API v1.2**. It improves base URL handling by normalizing hosts to consistently use **`/api/v1`**, enhances request behavior by optionally scoping requests to an organization via an **`org_id`** query parameter (inventory plugin), updates CI to pull a newer Flight Control e2e reference and run an **`e2e-registry`** locally, and adjusts integration tests to use that registry over **HTTP** (removing prior TLS-bypass behavior).

## Areas Affected

### Collection metadata / release docs
- **`galaxy.yml`**: `version: 1.5.0 → 1.6.0`
- **`CHANGELOG.rst`**: added **v1.6.0** release entry (“support Flight Control API v1.2” and a **Major Changes** bullet)
- **`changelogs/changelog.yaml`**: added **`releases.1.6.0`** with `release_summary`, reference to **`flightctl_1.6.0_update.yml`**, and `release_date: '2026-06-22'`
- **`README.md`**: pinned examples to **`flightctl.core:1.6.0`** (from `1.5.0`)

### Shared utilities (module client setup)
- **`plugins/module_utils/api_module.py`**
  - Normalizes `host_url` by trimming trailing `/` and ensuring it ends with **`/api/v1`**
  - Uses the normalized `host_url` when constructing `Configuration(...)` and `V1Alpha1Configuration(...)`

### Inventory plugin behavior
- **`plugins/inventory/flightctl.py`**
  - Normalizes the resolved Flight Control base `host` to end with **`/api/v1`**
  - If `config.organization` is set, scopes outgoing requests by appending **`org_id=<organization>`** (only when an `org_id` query param is not already present)
  - Adds helper `_set_org_id_query_param(client, organization)`

### Dependencies / test environment requirements
- **`requirements.txt`**: `flightctl-client 1.1.0 → 1.2.1`
- **`tests/unit/requirements.txt`**: `flightctl-client 1.1.0 → 1.2.1`
- **`tests/integration/requirements.txt`**: `flightctl-client 1.1.0 → 1.2.1`

### CI configuration
- **`.github/workflows/integration-tests.yaml`**
  - Updates `env.FLIGHTCTL_REF` to **`v1.2.0`** (from `v1.1.1`)
  - Replaces `make deploy-e2e-extras` with starting an **`e2e-registry`** container:
    - `docker run -d --name e2e-registry --network kind -p 5000:5000 quay.io/flightctl/e2eregistry:2`

### Integration tests
- **`tests/integration/targets/flightctl_image_builder/tasks/imagebuild-lifecycle.yml`**
  - Destination registry now uses **`e2e-registry:5000`** with **`scheme: http`**
  - Removes `skipServerVerification: true`
- **`tests/integration/targets/flightctl_image_builder/tasks/imageexport-lifecycle.yml`**
  - Destination registry now uses **`e2e-registry:5000`** with **`scheme: http`**
  - Removes `skipServerVerification: true`

## Module API surface / backward-compatibility implications
- **Module argument/return surface**: no changes indicated.
- **Behavioral compatibility considerations**
  - **URL normalization**: behavior changes when users provide hosts with trailing `/` or without `/api/v1` (now normalized more consistently).
  - **Organization scoping**: when `organization` is configured, requests will include **`org_id`**, potentially changing server-side results.
  - **Integration environment**: e2e registry interactions now use **HTTP** and remove the previous TLS bypass setting, so test environments must support the new registry endpoint/transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->