### PR TITLE
EDM-4975: Fix inventory env var fallback, OIDC-based username/password auth, and lazy jsonschema/PyYAML loading in ConfigLoader

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -71,7 +71,14 @@ build_ignore:
   - ".config"
   - ".ruff*"
   - ".tox*"
-  - "ci/"
+  - "ci"
+  - "tests/integration/integration_config.yml"
+  - "tox.ini"
+  - "pyproject.toml"
+  - "CHANGELOG.md"
+  - "*.tar.gz"
+  - ".*"
+  - "*/.*"
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style

--- a/plugins/inventory/flightctl.py
+++ b/plugins/inventory/flightctl.py
@@ -488,6 +488,9 @@ def _build_auth_headers(config: Configuration) -> Dict[str, str] | None:
         # sync short-circuit through the access_token branch above, instead of repeating
         # the discovery + token exchange handshake for every device/fleet/group listing.
         config.access_token = bearer_token
+        # No longer needed now that access_token is cached; drop them from memory.
+        config.username = None
+        config.password = None
         return {'Authorization': f'Bearer {bearer_token}'}
     return None
 

--- a/plugins/inventory/flightctl.py
+++ b/plugins/inventory/flightctl.py
@@ -42,22 +42,32 @@ options:
       description: URL to Flight Control server. A token or username/password must be also provided.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_HOST
     organization:
       description: Organization to scope Flight Control requests to.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_ORGANIZATION
     username:
-      description: Username for your Flight Control service. Please note that this only works with proxies configured to use HTTP Basic Auth.
+      description: Username for your Flight Control service.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_USERNAME
     password:
-      description: Password for your Flight Control service. Please note that this only works with proxies configured to use HTTP Basic Auth.
+      description: Password for your Flight Control service.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_PASSWORD
     token:
-      description: The Flight Control API token to use.
+      description: The Flight Control API token to use. If value not set, will try environment variable C(FLIGHTCTL_TOKEN).
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_TOKEN
     additional_groups:
       description: Additional groups to add devices to.
       type: list
@@ -100,6 +110,8 @@ options:
           C(service.certificate-authority-data) (base64-encoded PEM).
         - Any values defined in the inventory override values from this file.
       type: path
+      env:
+        - name: FLIGHTCTL_CONFIG_FILE
     hostnames:
       description: |
         Dotted path of the device field to use as the Ansible inventory hostname (for example, C(metadata.name) or C(status.systemInfo.hostname)).
@@ -133,6 +145,7 @@ else:
 
 from ..module_utils.config_loader import ConfigLoader
 from ..module_utils.exceptions import ValidationException, FlightctlApiException, FlightctlException
+from ..module_utils.oidc_auth import oidc_password_grant
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.utils.display import Display
 from contextlib import contextmanager
@@ -459,9 +472,23 @@ def _build_auth_headers(config: Configuration) -> Dict[str, str] | None:
     username = getattr(config, 'username', None)
     password = getattr(config, 'password', None)
     if username and password:
-        basic_credentials = f"{username}:{password}"
-        encoded_credentials = base64.b64encode(basic_credentials.encode('utf-8')).decode('utf-8')
-        return {'Authorization': f'Basic {encoded_credentials}'}
+        bearer_token, error_detail = oidc_password_grant(
+            host=getattr(config, 'host', None),
+            username=username,
+            password=password,
+            verify_ssl=getattr(config, 'verify_ssl', True),
+            ca_path=getattr(config, 'ssl_ca_cert', None),
+            request_timeout=getattr(config, 'request_timeout', None),
+        )
+        if not bearer_token:
+            raise ValidationException(
+                f"Failed to authenticate with username/password via OIDC password grant: {error_detail}"
+            )
+        # Cache the token on the Configuration so subsequent calls within this inventory
+        # sync short-circuit through the access_token branch above, instead of repeating
+        # the discovery + token exchange handshake for every device/fleet/group listing.
+        config.access_token = bearer_token
+        return {'Authorization': f'Bearer {bearer_token}'}
     return None
 
 

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -8,13 +8,13 @@ __metaclass__ = type
 
 import importlib
 from datetime import datetime
-from base64 import b64encode
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
 
 from .constants import API_MAPPING, NESTED_RESOURCES, ResourceType
 from .core import FlightctlModule
 from .exceptions import FlightctlException, FlightctlApiException
+from .oidc_auth import oidc_password_grant
 from .options import ApprovalOptions, GetOptions
 from .utils import diff_dicts, get_patch, json_patch
 
@@ -172,14 +172,27 @@ class FlightctlAPIModule(FlightctlModule):
         """
         Sets auth headers for the underlying client based on set parameters.
 
-        Prioritizes a set token if present on the module.
+        Prioritizes a set token if present on the module. If only a username and
+        password are provided, exchanges them for a Bearer token via an OIDC
+        password grant (mirroring `flightctl login --username --password`), since
+        the Flight Control API only accepts Bearer tokens on its endpoints.
         """
         if self.token:
             self.headers = {'Authorization': f'Bearer {self.token}'}
         elif self.username and self.password:
-            basic_credentials = f"{self.username}:{self.password}"
-            encoded_credentials = b64encode(basic_credentials.encode('utf-8')).decode('utf-8')
-            self.headers = {'Authorization': f'Basic {encoded_credentials}'}
+            bearer_token, error_detail = oidc_password_grant(
+                host=self.host,
+                username=self.username,
+                password=self.password,
+                verify_ssl=self.verify_ssl,
+                ca_path=self.ca_path,
+                request_timeout=self.request_timeout,
+            )
+            if not bearer_token:
+                self.fail_json(
+                    msg=f"Failed to authenticate with username/password via OIDC password grant: {error_detail}"
+                )
+            self.headers = {'Authorization': f'Bearer {bearer_token}'}
         else:
             self.headers = None
 

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -192,7 +192,14 @@ class FlightctlAPIModule(FlightctlModule):
                 self.fail_json(
                     msg=f"Failed to authenticate with username/password via OIDC password grant: {error_detail}"
                 )
+                # fail_json() only raises/exits when no error_callback is set; if a
+                # caller supplied a non-raising error_callback, stop here so we never
+                # fall through to sending "Authorization: Bearer None".
+                raise FlightctlException(f"Failed to authenticate: {error_detail}")
             self.headers = {'Authorization': f'Bearer {bearer_token}'}
+            # No longer needed now that we hold a bearer token; drop them from memory.
+            self.username = None
+            self.password = None
         else:
             self.headers = None
 

--- a/plugins/module_utils/config_loader.py
+++ b/plugins/module_utils/config_loader.py
@@ -25,11 +25,6 @@ from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 
 class ConfigLoader:
     def __init__(self, config_file=None, warn_callback=None):
-        if JSONSCHEMA_IMPORT_ERROR:
-            raise JSONSCHEMA_IMPORT_ERROR
-        if PYYAML_IMPORT_ERROR:
-            raise PYYAML_IMPORT_ERROR
-
         self._warn_callback = warn_callback
 
         # Assign token from config if it exists
@@ -44,6 +39,13 @@ class ConfigLoader:
 
     def _load_config_file(self, config_file):
         """Loads and validates the configuration from the provided file."""
+        # jsonschema/PyYAML are only required when a config_file is actually supplied,
+        # so the import checks live here rather than in __init__.
+        if JSONSCHEMA_IMPORT_ERROR:
+            raise JSONSCHEMA_IMPORT_ERROR
+        if PYYAML_IMPORT_ERROR:
+            raise PYYAML_IMPORT_ERROR
+
         # Define the schema for validation
         schema = {
             "type": "object",

--- a/plugins/module_utils/imagebuilder_module.py
+++ b/plugins/module_utils/imagebuilder_module.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 from typing import Any, Callable, Dict, Optional
 
 from .core import FlightctlModule
-from .exceptions import FlightctlApiException
+from .exceptions import FlightctlApiException, FlightctlException
 from .oidc_auth import oidc_password_grant
 
 try:
@@ -89,7 +89,14 @@ class FlightctlImageBuilderModule(FlightctlModule):
                 self.fail_json(
                     msg=f"Failed to authenticate with username/password via OIDC password grant: {error_detail}"
                 )
+                # fail_json() only raises/exits when no error_callback is set; if a
+                # caller supplied a non-raising error_callback, stop here so we never
+                # fall through to sending "Authorization: Bearer None".
+                raise FlightctlException(f"Failed to authenticate: {error_detail}")
             self.headers = {'Authorization': f'Bearer {bearer_token}'}
+            # No longer needed now that we hold a bearer token; drop them from memory.
+            self.username = None
+            self.password = None
         else:
             self.headers = None
 

--- a/plugins/module_utils/imagebuilder_module.py
+++ b/plugins/module_utils/imagebuilder_module.py
@@ -6,11 +6,11 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-from base64 import b64encode
 from typing import Any, Callable, Dict, Optional
 
 from .core import FlightctlModule
 from .exceptions import FlightctlApiException
+from .oidc_auth import oidc_password_grant
 
 try:
     from flightctl.imagebuilder.api_client import ApiClient
@@ -66,12 +66,30 @@ class FlightctlImageBuilderModule(FlightctlModule):
         self._imageexport_api = None
 
     def _set_auth_headers(self) -> None:
+        """
+        Sets auth headers for the underlying client based on set parameters.
+
+        Prioritizes a set token if present on the module. If only a username and
+        password are provided, exchanges them for a Bearer token via an OIDC
+        password grant (mirroring `flightctl login --username --password`), since
+        the Flight Control API only accepts Bearer tokens on its endpoints.
+        """
         if self.token:
             self.headers = {'Authorization': f'Bearer {self.token}'}
         elif self.username and self.password:
-            basic_credentials = f"{self.username}:{self.password}"
-            encoded = b64encode(basic_credentials.encode('utf-8')).decode('utf-8')
-            self.headers = {'Authorization': f'Basic {encoded}'}
+            bearer_token, error_detail = oidc_password_grant(
+                host=self.host,
+                username=self.username,
+                password=self.password,
+                verify_ssl=self.verify_ssl,
+                ca_path=self.ca_path,
+                request_timeout=self.request_timeout,
+            )
+            if not bearer_token:
+                self.fail_json(
+                    msg=f"Failed to authenticate with username/password via OIDC password grant: {error_detail}"
+                )
+            self.headers = {'Authorization': f'Bearer {bearer_token}'}
         else:
             self.headers = None
 

--- a/plugins/module_utils/oidc_auth.py
+++ b/plugins/module_utils/oidc_auth.py
@@ -27,8 +27,9 @@ from ansible.module_utils.urls import open_url
 
 
 def http_get_json(url: str, verify_ssl: bool, ca_path: Optional[str], request_timeout: Optional[float]) -> Dict[str, Any]:
-    response = open_url(url, method='GET', validate_certs=verify_ssl, ca_path=ca_path,
-                         timeout=request_timeout or 30)
+    response = open_url(
+        url, method='GET', validate_certs=verify_ssl, ca_path=ca_path, timeout=request_timeout or 30,
+    )
     return json.loads(response.read())
 
 

--- a/plugins/module_utils/oidc_auth.py
+++ b/plugins/module_utils/oidc_auth.py
@@ -1,0 +1,150 @@
+# coding: utf-8 -*-
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Shared helpers implementing the OIDC Resource Owner Password Credentials (ROPC)
+grant used to exchange a username/password for a bearer token.
+
+The Flight Control API's middlewares only accept Bearer tokens (they extract
+credentials via ExtractBearerToken() exclusively); HTTP Basic Auth is rejected
+on API endpoints. Any code path that accepts a username/password must therefore
+discover the server's configured OIDC provider and exchange the credentials for
+a token, mirroring what `flightctl login --username --password` does internally,
+rather than sending them as HTTP Basic Auth.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import json
+from typing import Any, Dict, Optional, Tuple
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+
+from ansible.module_utils.urls import open_url
+
+
+def http_get_json(url: str, verify_ssl: bool, ca_path: Optional[str], request_timeout: Optional[float]) -> Dict[str, Any]:
+    response = open_url(url, method='GET', validate_certs=verify_ssl, ca_path=ca_path,
+                         timeout=request_timeout or 30)
+    return json.loads(response.read())
+
+
+def discover_oidc_token_endpoint(
+    host: Optional[str],
+    verify_ssl: bool,
+    ca_path: Optional[str],
+    request_timeout: Optional[float],
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """
+    Discover the OIDC token endpoint and client_id for the server's configured
+    authentication provider by querying /auth/config and the provider's own
+    OIDC discovery document, mirroring what `flightctl login` does internally.
+
+    Returns (token_endpoint, client_id, error_detail). On failure, token_endpoint is
+    None and error_detail explains why (for surfacing back to the user).
+    """
+    if not host:
+        return None, None, "no host is configured"
+    # The caller may pass a host with a trailing /api/v1 (as used for API requests);
+    # the auth config/discovery endpoints live under the bare host.
+    base_host = host.rstrip('/')
+    if base_host.endswith('/api/v1'):
+        base_host = base_host[:-len('/api/v1')].rstrip('/')
+
+    auth_config_url = f"{base_host}/api/v1/auth/config"
+    try:
+        auth_config = http_get_json(auth_config_url, verify_ssl, ca_path, request_timeout)
+    except Exception as e:
+        return None, None, f"failed to fetch authentication config from {auth_config_url}: {e}"
+
+    providers = auth_config.get('providers') or []
+    default_provider_name = auth_config.get('defaultProvider')
+    oidc_specs = []
+    for provider in providers:
+        spec = provider.get('spec') or {}
+        if spec.get('providerType') != 'oidc':
+            continue
+        provider_name = (provider.get('metadata') or {}).get('name')
+        oidc_specs.append((provider_name, spec))
+
+    if not oidc_specs:
+        return None, None, "the server has no OIDC-based authentication provider configured"
+
+    # Prefer the default provider, if it is an OIDC one, otherwise use the first OIDC provider found.
+    chosen_spec = next((spec for name, spec in oidc_specs if name == default_provider_name), oidc_specs[0][1])
+    issuer = chosen_spec.get('issuer')
+    client_id = chosen_spec.get('clientId')
+    if not issuer:
+        return None, client_id, "the configured OIDC provider has no issuer URL"
+
+    discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    try:
+        discovery = http_get_json(discovery_url, verify_ssl, ca_path, request_timeout)
+    except Exception as e:
+        return None, client_id, f"failed to fetch OIDC discovery document from {discovery_url}: {e}"
+
+    token_endpoint = discovery.get('token_endpoint')
+    if not token_endpoint:
+        return None, client_id, f"OIDC discovery document at {discovery_url} does not advertise a token_endpoint"
+
+    return token_endpoint, client_id, None
+
+
+def oidc_password_grant(
+    host: Optional[str],
+    username: str,
+    password: str,
+    verify_ssl: bool = True,
+    ca_path: Optional[str] = None,
+    request_timeout: Optional[float] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Perform an OIDC Resource Owner Password Credentials grant against the server's
+    configured authentication provider. Returns (bearer_token, error_detail): on success
+    bearer_token is the id_token (falling back to access_token) and error_detail is None;
+    on failure bearer_token is None and error_detail explains why.
+    """
+    token_endpoint, client_id, error_detail = discover_oidc_token_endpoint(host, verify_ssl, ca_path, request_timeout)
+    if error_detail:
+        return None, error_detail
+    if not token_endpoint or not client_id:
+        return None, "could not determine an OIDC token endpoint and client_id for the server"
+
+    form_data = urlencode({
+        'grant_type': 'password',
+        'username': username,
+        'password': password,
+        'client_id': client_id,
+        'scope': 'openid',
+    })
+
+    try:
+        response = open_url(
+            token_endpoint,
+            method='POST',
+            data=form_data,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            validate_certs=verify_ssl,
+            ca_path=ca_path,
+            timeout=request_timeout or 30,
+        )
+        token_data = json.loads(response.read())
+    except HTTPError as e:
+        try:
+            error_body = json.loads(e.read())
+            reason = error_body.get('error_description') or error_body.get('error') or e.reason
+        except Exception:
+            reason = e.reason
+        return None, f"token endpoint {token_endpoint} rejected the request ({e.code}): {reason}"
+    except Exception as e:
+        return None, f"failed to reach token endpoint {token_endpoint}: {e}"
+
+    bearer_token = token_data.get('id_token') or token_data.get('access_token')
+    if not bearer_token:
+        reason = token_data.get('error_description') or token_data.get('error') or "no id_token or access_token in response"
+        return None, f"token endpoint {token_endpoint} did not return a usable token: {reason}"
+
+    return bearer_token, None

--- a/tests/unit/plugins/inventory/test_flightctl.py
+++ b/tests/unit/plugins/inventory/test_flightctl.py
@@ -1,8 +1,19 @@
+import io
+import json
 import unittest
+from urllib.error import HTTPError
 from unittest.mock import patch, MagicMock
 
 # Import your inventory module
-from plugins.inventory.flightctl import InventoryModule, _render_hostname_expression, _resolve_hostname, _validate_device
+from plugins.inventory.flightctl import (
+    InventoryModule,
+    _render_hostname_expression,
+    _resolve_hostname,
+    _validate_device,
+    _build_auth_headers,
+)
+from plugins.module_utils.exceptions import ValidationException
+from flightctl.configuration import Configuration
 
 
 class TestFlightCtlInventoryModule(unittest.TestCase):
@@ -519,6 +530,124 @@ class TestValidateDeviceWithExpressions(unittest.TestCase):
         device_id, metadata = _validate_device(device, "metadata.name + '_' + metadata.uid")
         self.assertEqual(device_id, 'device1_')
         self.assertEqual(metadata, device['metadata'])
+
+
+def _fake_http_response(data):
+    """Build a stand-in for what ansible.module_utils.urls.open_url() returns."""
+    response = MagicMock()
+    response.read.return_value = json.dumps(data).encode('utf-8')
+    return response
+
+
+AUTH_CONFIG_RESPONSE = {
+    'apiVersion': 'v1beta1',
+    'defaultProvider': 'pam-issuer',
+    'providers': [{
+        'apiVersion': 'v1beta1',
+        'kind': 'AuthProvider',
+        'metadata': {'name': 'pam-issuer'},
+        'spec': {
+            'providerType': 'oidc',
+            'issuer': 'https://issuer.example.com/_/pam-issuer',
+            'clientId': 'flightctl-client',
+        },
+    }],
+}
+
+OIDC_DISCOVERY_RESPONSE = {
+    'issuer': 'https://issuer.example.com/_/pam-issuer',
+    'token_endpoint': 'https://issuer.example.com/_/pam-issuer/api/v1/auth/token',
+}
+
+
+class TestBuildAuthHeaders(unittest.TestCase):
+    """Test suite for _build_auth_headers (Bug 2 - OIDC password grant)"""
+
+    def test_plain_token_returns_bearer_without_http_calls(self):
+        """A configured access_token should be used directly with no HTTP calls."""
+        config = Configuration(host='https://flightctl.example.com/api/v1', access_token='my-token')
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            headers = _build_auth_headers(config)
+        mock_open_url.assert_not_called()
+        self.assertEqual(headers, {'Authorization': 'Bearer my-token'})
+
+    def test_username_password_performs_oidc_discovery_and_grant(self):
+        """username/password should trigger discovery + a password grant, not Basic auth."""
+        config = Configuration(host='https://flightctl.example.com/api/v1', username='alice', password='s3cret')
+        token_response = _fake_http_response({'access_token': 'access-1', 'id_token': 'id-token-1', 'token_type': 'Bearer'})
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                token_response,
+            ]
+            headers = _build_auth_headers(config)
+
+        self.assertEqual(headers, {'Authorization': 'Bearer id-token-1'})
+        self.assertEqual(mock_open_url.call_count, 3)
+
+        # Confirm no Basic auth header was ever produced.
+        for call in mock_open_url.call_args_list:
+            self.assertNotIn('Basic', str(call))
+
+        # Confirm the password grant was POSTed to the discovered token endpoint.
+        post_call = mock_open_url.call_args_list[2]
+        self.assertEqual(post_call.args[0], OIDC_DISCOVERY_RESPONSE['token_endpoint'])
+        self.assertEqual(post_call.kwargs.get('method'), 'POST')
+        self.assertIn('grant_type=password', post_call.kwargs.get('data'))
+
+    def test_bearer_token_is_cached_on_configuration(self):
+        """A second call for the same Configuration should not repeat the OIDC handshake."""
+        config = Configuration(host='https://flightctl.example.com/api/v1', username='alice', password='s3cret')
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                _fake_http_response({'id_token': 'id-token-1'}),
+            ]
+            first_headers = _build_auth_headers(config)
+            second_headers = _build_auth_headers(config)
+
+        self.assertEqual(first_headers, second_headers)
+        # Only the first call should have hit the network; the second short-circuits
+        # via config.access_token, which _build_auth_headers set after the first grant.
+        self.assertEqual(mock_open_url.call_count, 3)
+        self.assertEqual(config.access_token, 'id-token-1')
+
+    def test_invalid_credentials_raise_with_upstream_error_detail(self):
+        """A 400 from the token endpoint should surface the upstream error_description."""
+        config = Configuration(host='https://flightctl.example.com/api/v1', username='alice', password='wrong')
+        error_body = json.dumps({'error': 'invalid_grant', 'error_description': 'Invalid user credentials'}).encode('utf-8')
+        http_error = HTTPError(url='https://issuer.example.com/token', code=400, msg='Bad Request',
+                                hdrs=None, fp=io.BytesIO(error_body))
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                http_error,
+            ]
+            with self.assertRaises(ValidationException) as context:
+                _build_auth_headers(config)
+
+        self.assertIn('Invalid user credentials', str(context.exception))
+
+    def test_no_oidc_provider_configured_raises_descriptive_error(self):
+        """If the server has no OIDC provider, the error should say so rather than a generic failure."""
+        config = Configuration(host='https://flightctl.example.com/api/v1', username='alice', password='s3cret')
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.return_value = _fake_http_response({'providers': []})
+            with self.assertRaises(ValidationException) as context:
+                _build_auth_headers(config)
+
+        self.assertIn('no OIDC-based authentication provider', str(context.exception))
+
+    def test_no_credentials_returns_none(self):
+        """No token and no username/password should return None (unauthenticated)."""
+        config = Configuration(host='https://flightctl.example.com/api/v1')
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            headers = _build_auth_headers(config)
+        mock_open_url.assert_not_called()
+        self.assertIsNone(headers)
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/inventory/test_flightctl.py
+++ b/tests/unit/plugins/inventory/test_flightctl.py
@@ -586,6 +586,10 @@ class TestBuildAuthHeaders(unittest.TestCase):
         self.assertEqual(headers, {'Authorization': 'Bearer id-token-1'})
         self.assertEqual(mock_open_url.call_count, 3)
 
+        # Credentials are no longer needed once a bearer token has been cached.
+        self.assertIsNone(config.username)
+        self.assertIsNone(config.password)
+
         # Confirm no Basic auth header was ever produced.
         for call in mock_open_url.call_args_list:
             self.assertNotIn('Basic', str(call))
@@ -618,8 +622,9 @@ class TestBuildAuthHeaders(unittest.TestCase):
         """A 400 from the token endpoint should surface the upstream error_description."""
         config = Configuration(host='https://flightctl.example.com/api/v1', username='alice', password='wrong')
         error_body = json.dumps({'error': 'invalid_grant', 'error_description': 'Invalid user credentials'}).encode('utf-8')
-        http_error = HTTPError(url='https://issuer.example.com/token', code=400, msg='Bad Request',
-                                hdrs=None, fp=io.BytesIO(error_body))
+        http_error = HTTPError(
+            url='https://issuer.example.com/token', code=400, msg='Bad Request', hdrs=None, fp=io.BytesIO(error_body),
+        )
         with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
             mock_open_url.side_effect = [
                 _fake_http_response(AUTH_CONFIG_RESPONSE),

--- a/tests/unit/plugins/module_utils/test_api_module.py
+++ b/tests/unit/plugins/module_utils/test_api_module.py
@@ -48,7 +48,8 @@ def api_module_with_user_pass():
         flightctl_username='test-user',
         flightctl_password='test-pass'
     ))
-    return FlightctlAPIModule(argument_spec={})
+    with patch('plugins.module_utils.api_module.oidc_password_grant', return_value=('oidc-bearer-token', None)):
+        return FlightctlAPIModule(argument_spec={})
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -132,7 +133,8 @@ def test_token_auth(mock_api, api_module_with_token):
 
 
 @patch('plugins.module_utils.api_module.CertificatesigningrequestApi')
-def test_basic_auth(mock_api, api_module_with_user_pass):
+def test_username_password_uses_oidc_bearer_token(mock_api, api_module_with_user_pass):
+    """username/password must be exchanged for a Bearer token via OIDC, never sent as Basic auth."""
     mock_api_instance = MagicMock()
     mock_api.return_value = mock_api_instance
     mock_csr = MagicMock(spec=CertificateSigningRequest)
@@ -145,9 +147,51 @@ def test_basic_auth(mock_api, api_module_with_user_pass):
     mock_api_instance.update_certificate_signing_request_approval.assert_called_with(
         input.name,
         mock_csr,
-        _headers={'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcGFzcw=='},
+        _headers={'Authorization': 'Bearer oidc-bearer-token'},
         _request_timeout=10
     )
+
+
+def test_username_password_performs_oidc_grant_with_module_connection_params():
+    """set_auth() should forward the module's host/verify_ssl/ca_path/timeout to the OIDC helper."""
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_username='test-user',
+        flightctl_password='test-pass',
+        flightctl_validate_certs=False,
+    ))
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value=('oidc-bearer-token', None),
+    ) as mock_grant:
+        module = FlightctlAPIModule(argument_spec={})
+
+    mock_grant.assert_called_once_with(
+        host=module.host,
+        username='test-user',
+        password='test-pass',
+        verify_ssl=False,
+        ca_path=None,
+        request_timeout=10,
+    )
+    assert module.headers == {'Authorization': 'Bearer oidc-bearer-token'}
+
+
+def test_username_password_oidc_failure_fails_module():
+    """A failed OIDC grant should fail the module with the upstream error detail, not silently fall back."""
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_username='test-user',
+        flightctl_password='test-pass',
+    ))
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value=(None, 'the server has no OIDC-based authentication provider configured'),
+    ), patch.object(FlightctlAPIModule, 'fail_json', side_effect=SystemExit(1)) as mock_fail:
+        with pytest.raises(SystemExit):
+            FlightctlAPIModule(argument_spec={})
+
+    assert 'no OIDC-based authentication provider configured' in mock_fail.call_args.kwargs['msg']
 
 
 # --- AuthProvider tests ---

--- a/tests/unit/plugins/module_utils/test_api_module.py
+++ b/tests/unit/plugins/module_utils/test_api_module.py
@@ -175,6 +175,9 @@ def test_username_password_performs_oidc_grant_with_module_connection_params():
         request_timeout=10,
     )
     assert module.headers == {'Authorization': 'Bearer oidc-bearer-token'}
+    # Credentials are no longer needed once a bearer token has been obtained.
+    assert module.username is None
+    assert module.password is None
 
 
 def test_username_password_oidc_failure_fails_module():
@@ -192,6 +195,25 @@ def test_username_password_oidc_failure_fails_module():
             FlightctlAPIModule(argument_spec={})
 
     assert 'no OIDC-based authentication provider configured' in mock_fail.call_args.kwargs['msg']
+
+
+def test_username_password_oidc_failure_with_non_raising_error_callback_still_raises():
+    """
+    fail_json() only raises/exits when no error_callback is set. If a caller supplies a
+    non-raising error_callback, set_auth() must still stop instead of falling through to
+    sending "Authorization: Bearer None".
+    """
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_username='test-user',
+        flightctl_password='test-pass',
+    ))
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value=(None, 'the server has no OIDC-based authentication provider configured'),
+    ):
+        with pytest.raises(FlightctlException):
+            FlightctlAPIModule(argument_spec={}, error_callback=MagicMock())
 
 
 # --- AuthProvider tests ---

--- a/tests/unit/plugins/module_utils/test_config_loader.py
+++ b/tests/unit/plugins/module_utils/test_config_loader.py
@@ -1,0 +1,73 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import pytest
+
+from plugins.module_utils import config_loader
+from plugins.module_utils.config_loader import ConfigLoader
+
+
+class TestConfigLoaderMissingJsonschema:
+    """
+    Bug 3 regression tests: jsonschema/PyYAML should only be required when a
+    config_file is actually supplied, not unconditionally on __init__.
+    """
+
+    def test_init_without_config_file_succeeds_when_jsonschema_missing(self, monkeypatch):
+        monkeypatch.setattr(config_loader, 'JSONSCHEMA_IMPORT_ERROR', ImportError('no module named jsonschema'))
+
+        loader = ConfigLoader(config_file=None)
+
+        assert isinstance(loader, ConfigLoader)
+
+    def test_init_without_config_file_succeeds_when_pyyaml_missing(self, monkeypatch):
+        monkeypatch.setattr(config_loader, 'PYYAML_IMPORT_ERROR', ImportError('no module named yaml'))
+
+        loader = ConfigLoader(config_file=None)
+
+        assert isinstance(loader, ConfigLoader)
+
+    def test_init_with_config_file_still_raises_when_jsonschema_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, 'JSONSCHEMA_IMPORT_ERROR', ImportError('no module named jsonschema'))
+        config_file = tmp_path / "client.yaml"
+        config_file.write_text("authentication:\n  access-token: abc\nservice:\n  server: https://example.com\n")
+
+        with pytest.raises(ImportError, match="no module named jsonschema"):
+            ConfigLoader(config_file=str(config_file))
+
+    def test_init_with_config_file_still_raises_when_pyyaml_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, 'PYYAML_IMPORT_ERROR', ImportError('no module named yaml'))
+        config_file = tmp_path / "client.yaml"
+        config_file.write_text("authentication:\n  access-token: abc\nservice:\n  server: https://example.com\n")
+
+        with pytest.raises(ImportError, match="no module named yaml"):
+            ConfigLoader(config_file=str(config_file))
+
+
+class TestConfigLoaderParsing:
+    """Sanity checks that normal config file parsing still works when dependencies are present."""
+
+    def test_parses_token_host_and_organization(self, tmp_path):
+        config_file = tmp_path / "client.yaml"
+        config_file.write_text(
+            "organization: my-org\n"
+            "authentication:\n"
+            "  access-token: my-access-token\n"
+            "service:\n"
+            "  server: https://flightctl.example.com\n"
+            "  insecureSkipVerify: true\n"
+        )
+
+        loader = ConfigLoader(config_file=str(config_file))
+
+        assert loader.token == "my-access-token"
+        assert loader.organization == "my-org"
+        assert loader.host == "https://flightctl.example.com"
+        assert loader.verify_ssl is False
+
+    def test_missing_config_file_raises_clear_error(self, tmp_path):
+        missing_path = tmp_path / "does_not_exist.yaml"
+
+        with pytest.raises(Exception, match="was not found"):
+            ConfigLoader(config_file=str(missing_path))

--- a/tests/unit/plugins/module_utils/test_imagebuilder_module.py
+++ b/tests/unit/plugins/module_utils/test_imagebuilder_module.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from tests.unit.utils import set_module_args
-from plugins.module_utils.exceptions import FlightctlApiException
+from plugins.module_utils.exceptions import FlightctlApiException, FlightctlException
 
 
 @pytest.fixture
@@ -52,12 +52,14 @@ class TestAuthHeaders:
             flightctl_password='secret',
             flightctl_validate_certs=False,
         ))
-        with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
-             patch('plugins.module_utils.imagebuilder_module.Configuration'), \
-             patch(
+        with (
+            patch('plugins.module_utils.imagebuilder_module.ApiClient'),
+            patch('plugins.module_utils.imagebuilder_module.Configuration'),
+            patch(
                 'plugins.module_utils.imagebuilder_module.oidc_password_grant',
                 return_value=('oidc-bearer-token', None),
-             ) as mock_grant:
+            ) as mock_grant,
+        ):
             from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
             module = FlightctlImageBuilderModule(argument_spec={})
 
@@ -69,6 +71,9 @@ class TestAuthHeaders:
             ca_path=None,
             request_timeout=10,
         )
+        # Credentials are no longer needed once a bearer token has been obtained.
+        assert module.username is None
+        assert module.password is None
 
     def test_username_password_oidc_failure_fails_module(self):
         """A failed OIDC grant should fail the module with the upstream error detail."""
@@ -78,17 +83,42 @@ class TestAuthHeaders:
             flightctl_password='secret',
         ))
         from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
-        with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
-             patch('plugins.module_utils.imagebuilder_module.Configuration'), \
-             patch(
+        with (
+            patch('plugins.module_utils.imagebuilder_module.ApiClient'),
+            patch('plugins.module_utils.imagebuilder_module.Configuration'),
+            patch(
                 'plugins.module_utils.imagebuilder_module.oidc_password_grant',
                 return_value=(None, 'the server has no OIDC-based authentication provider configured'),
-             ), \
-             patch.object(FlightctlImageBuilderModule, 'fail_json', side_effect=SystemExit(1)) as mock_fail:
+            ),
+            patch.object(FlightctlImageBuilderModule, 'fail_json', side_effect=SystemExit(1)) as mock_fail,
+        ):
             with pytest.raises(SystemExit):
                 FlightctlImageBuilderModule(argument_spec={})
 
         assert 'no OIDC-based authentication provider configured' in mock_fail.call_args.kwargs['msg']
+
+    def test_username_password_oidc_failure_with_non_raising_error_callback_still_raises(self):
+        """
+        fail_json() only raises/exits when no error_callback is set. If a caller supplies a
+        non-raising error_callback, _set_auth_headers() must still stop instead of falling
+        through to sending "Authorization: Bearer None".
+        """
+        set_module_args(dict(
+            flightctl_host='https://test-imagebuilder.com/',
+            flightctl_username='admin',
+            flightctl_password='secret',
+        ))
+        from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
+        with (
+            patch('plugins.module_utils.imagebuilder_module.ApiClient'),
+            patch('plugins.module_utils.imagebuilder_module.Configuration'),
+            patch(
+                'plugins.module_utils.imagebuilder_module.oidc_password_grant',
+                return_value=(None, 'the server has no OIDC-based authentication provider configured'),
+            ),
+        ):
+            with pytest.raises(FlightctlException):
+                FlightctlImageBuilderModule(argument_spec={}, error_callback=MagicMock())
 
     def test_no_auth(self):
         set_module_args(dict(

--- a/tests/unit/plugins/module_utils/test_imagebuilder_module.py
+++ b/tests/unit/plugins/module_utils/test_imagebuilder_module.py
@@ -4,7 +4,6 @@ __metaclass__ = type
 
 import pytest
 from unittest.mock import MagicMock, patch
-from base64 import b64encode
 
 from tests.unit.utils import set_module_args
 from plugins.module_utils.exceptions import FlightctlApiException
@@ -24,14 +23,15 @@ def ib_module():
 
 
 @pytest.fixture
-def ib_module_basic_auth():
+def ib_module_user_pass():
     set_module_args(dict(
         flightctl_host='https://test-imagebuilder.com/',
         flightctl_username='admin',
         flightctl_password='secret'
     ))
     with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
-         patch('plugins.module_utils.imagebuilder_module.Configuration'):
+         patch('plugins.module_utils.imagebuilder_module.Configuration'), \
+         patch('plugins.module_utils.imagebuilder_module.oidc_password_grant', return_value=('oidc-bearer-token', None)):
         from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
         module = FlightctlImageBuilderModule(argument_spec={})
     return module
@@ -41,9 +41,54 @@ class TestAuthHeaders:
     def test_bearer_token(self, ib_module):
         assert ib_module.headers == {'Authorization': 'Bearer test-token'}
 
-    def test_basic_auth(self, ib_module_basic_auth):
-        expected = b64encode(b'admin:secret').decode('utf-8')
-        assert ib_module_basic_auth.headers == {'Authorization': f'Basic {expected}'}
+    def test_username_password_uses_oidc_bearer_token(self, ib_module_user_pass):
+        """username/password must be exchanged for a Bearer token via OIDC, never sent as Basic auth."""
+        assert ib_module_user_pass.headers == {'Authorization': 'Bearer oidc-bearer-token'}
+
+    def test_username_password_performs_oidc_grant_with_module_connection_params(self):
+        set_module_args(dict(
+            flightctl_host='https://test-imagebuilder.com/',
+            flightctl_username='admin',
+            flightctl_password='secret',
+            flightctl_validate_certs=False,
+        ))
+        with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
+             patch('plugins.module_utils.imagebuilder_module.Configuration'), \
+             patch(
+                'plugins.module_utils.imagebuilder_module.oidc_password_grant',
+                return_value=('oidc-bearer-token', None),
+             ) as mock_grant:
+            from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
+            module = FlightctlImageBuilderModule(argument_spec={})
+
+        mock_grant.assert_called_once_with(
+            host=module.host,
+            username='admin',
+            password='secret',
+            verify_ssl=False,
+            ca_path=None,
+            request_timeout=10,
+        )
+
+    def test_username_password_oidc_failure_fails_module(self):
+        """A failed OIDC grant should fail the module with the upstream error detail."""
+        set_module_args(dict(
+            flightctl_host='https://test-imagebuilder.com/',
+            flightctl_username='admin',
+            flightctl_password='secret',
+        ))
+        from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
+        with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
+             patch('plugins.module_utils.imagebuilder_module.Configuration'), \
+             patch(
+                'plugins.module_utils.imagebuilder_module.oidc_password_grant',
+                return_value=(None, 'the server has no OIDC-based authentication provider configured'),
+             ), \
+             patch.object(FlightctlImageBuilderModule, 'fail_json', side_effect=SystemExit(1)) as mock_fail:
+            with pytest.raises(SystemExit):
+                FlightctlImageBuilderModule(argument_spec={})
+
+        assert 'no OIDC-based authentication provider configured' in mock_fail.call_args.kwargs['msg']
 
     def test_no_auth(self):
         set_module_args(dict(

--- a/tests/unit/plugins/module_utils/test_oidc_auth.py
+++ b/tests/unit/plugins/module_utils/test_oidc_auth.py
@@ -164,8 +164,9 @@ class TestOidcPasswordGrant:
 
     def test_invalid_credentials_surface_upstream_error_description(self):
         error_body = json.dumps({'error': 'invalid_grant', 'error_description': 'Invalid user credentials'}).encode('utf-8')
-        http_error = HTTPError(url='https://issuer.example.com/token', code=400, msg='Bad Request',
-                                hdrs=None, fp=io.BytesIO(error_body))
+        http_error = HTTPError(
+            url='https://issuer.example.com/token', code=400, msg='Bad Request', hdrs=None, fp=io.BytesIO(error_body),
+        )
         with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
             mock_open_url.side_effect = [
                 _fake_http_response(AUTH_CONFIG_RESPONSE),

--- a/tests/unit/plugins/module_utils/test_oidc_auth.py
+++ b/tests/unit/plugins/module_utils/test_oidc_auth.py
@@ -1,0 +1,208 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import io
+import json
+from unittest.mock import patch, MagicMock
+from urllib.error import HTTPError
+
+from plugins.module_utils.oidc_auth import discover_oidc_token_endpoint, oidc_password_grant
+
+
+def _fake_http_response(data):
+    """Build a stand-in for what ansible.module_utils.urls.open_url() returns."""
+    response = MagicMock()
+    response.read.return_value = json.dumps(data).encode('utf-8')
+    return response
+
+
+AUTH_CONFIG_RESPONSE = {
+    'apiVersion': 'v1beta1',
+    'defaultProvider': 'pam-issuer',
+    'providers': [{
+        'apiVersion': 'v1beta1',
+        'kind': 'AuthProvider',
+        'metadata': {'name': 'pam-issuer'},
+        'spec': {
+            'providerType': 'oidc',
+            'issuer': 'https://issuer.example.com/_/pam-issuer',
+            'clientId': 'flightctl-client',
+        },
+    }],
+}
+
+OIDC_DISCOVERY_RESPONSE = {
+    'issuer': 'https://issuer.example.com/_/pam-issuer',
+    'token_endpoint': 'https://issuer.example.com/_/pam-issuer/api/v1/auth/token',
+}
+
+
+class TestDiscoverOidcTokenEndpoint:
+
+    def test_no_host_returns_error(self):
+        token_endpoint, client_id, error = discover_oidc_token_endpoint(None, True, None, None)
+        assert token_endpoint is None
+        assert client_id is None
+        assert 'no host is configured' in error
+
+    def test_strips_trailing_api_v1_before_fetching_auth_config(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+            ]
+            token_endpoint, client_id, error = discover_oidc_token_endpoint(
+                'https://flightctl.example.com/api/v1', True, None, None
+            )
+
+        assert error is None
+        assert token_endpoint == OIDC_DISCOVERY_RESPONSE['token_endpoint']
+        assert client_id == 'flightctl-client'
+        auth_config_call = mock_open_url.call_args_list[0]
+        assert auth_config_call.args[0] == 'https://flightctl.example.com/api/v1/auth/config'
+
+    def test_no_oidc_provider_configured(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.return_value = _fake_http_response({'providers': []})
+            token_endpoint, client_id, error = discover_oidc_token_endpoint(
+                'https://flightctl.example.com', True, None, None
+            )
+
+        assert token_endpoint is None
+        assert 'no OIDC-based authentication provider' in error
+
+    def test_auth_config_fetch_failure_is_surfaced(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = Exception('connection refused')
+            token_endpoint, client_id, error = discover_oidc_token_endpoint(
+                'https://flightctl.example.com', True, None, None
+            )
+
+        assert token_endpoint is None
+        assert client_id is None
+        assert 'failed to fetch authentication config' in error
+
+    def test_missing_issuer_on_provider(self):
+        response = {
+            'providers': [{
+                'metadata': {'name': 'p1'},
+                'spec': {'providerType': 'oidc', 'clientId': 'client1'},
+            }],
+        }
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.return_value = _fake_http_response(response)
+            token_endpoint, client_id, error = discover_oidc_token_endpoint(
+                'https://flightctl.example.com', True, None, None
+            )
+
+        assert token_endpoint is None
+        assert client_id == 'client1'
+        assert 'no issuer URL' in error
+
+    def test_discovery_document_missing_token_endpoint(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response({'issuer': 'https://issuer.example.com/_/pam-issuer'}),
+            ]
+            token_endpoint, client_id, error = discover_oidc_token_endpoint(
+                'https://flightctl.example.com', True, None, None
+            )
+
+        assert token_endpoint is None
+        assert client_id == 'flightctl-client'
+        assert 'does not advertise a token_endpoint' in error
+
+
+class TestOidcPasswordGrant:
+
+    def test_successful_grant_returns_id_token(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                _fake_http_response({'access_token': 'access-1', 'id_token': 'id-token-1'}),
+            ]
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 's3cret'
+            )
+
+        assert error is None
+        assert bearer_token == 'id-token-1'
+        assert mock_open_url.call_count == 3
+        post_call = mock_open_url.call_args_list[2]
+        assert post_call.args[0] == OIDC_DISCOVERY_RESPONSE['token_endpoint']
+        assert post_call.kwargs.get('method') == 'POST'
+        assert 'grant_type=password' in post_call.kwargs.get('data')
+
+    def test_falls_back_to_access_token_when_no_id_token(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                _fake_http_response({'access_token': 'access-1'}),
+            ]
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 's3cret'
+            )
+
+        assert error is None
+        assert bearer_token == 'access-1'
+
+    def test_discovery_failure_short_circuits_before_posting_credentials(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.return_value = _fake_http_response({'providers': []})
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 's3cret'
+            )
+
+        assert bearer_token is None
+        assert 'no OIDC-based authentication provider' in error
+        # Only the auth-config lookup should have happened; credentials must never be posted.
+        assert mock_open_url.call_count == 1
+
+    def test_invalid_credentials_surface_upstream_error_description(self):
+        error_body = json.dumps({'error': 'invalid_grant', 'error_description': 'Invalid user credentials'}).encode('utf-8')
+        http_error = HTTPError(url='https://issuer.example.com/token', code=400, msg='Bad Request',
+                                hdrs=None, fp=io.BytesIO(error_body))
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                http_error,
+            ]
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 'wrong'
+            )
+
+        assert bearer_token is None
+        assert 'Invalid user credentials' in error
+
+    def test_token_endpoint_unreachable(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                Exception('connection reset'),
+            ]
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 's3cret'
+            )
+
+        assert bearer_token is None
+        assert 'failed to reach token endpoint' in error
+
+    def test_response_without_usable_token(self):
+        with patch('plugins.module_utils.oidc_auth.open_url') as mock_open_url:
+            mock_open_url.side_effect = [
+                _fake_http_response(AUTH_CONFIG_RESPONSE),
+                _fake_http_response(OIDC_DISCOVERY_RESPONSE),
+                _fake_http_response({'token_type': 'Bearer'}),
+            ]
+            bearer_token, error = oidc_password_grant(
+                'https://flightctl.example.com/api/v1', 'alice', 's3cret'
+            )
+
+        assert bearer_token is None
+        assert 'did not return a usable token' in error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated authentication in `plugins/inventory/`, `plugins/module_utils/`, and shared OIDC utilities.
- Username/password credentials now use OIDC password-grant authentication and Bearer tokens.
- Added OIDC discovery and token-exchange helpers with TLS, CA, timeout, and error handling.
- Cached inventory tokens and cleared stored credentials after successful authentication.
- Deferred `jsonschema` and PyYAML checks until `ConfigLoader` loads a configuration file.
- Expanded `galaxy.yml` `build_ignore` patterns for CI files, tooling, changelogs, archives, and hidden files.

## Tests

- Added OIDC tests for discovery, token fallback, credential errors, transport failures, and invalid responses.
- Updated inventory, API module, and Image Builder authentication tests.
- Added `ConfigLoader` tests for deferred dependencies, YAML parsing, and missing files.

## API and compatibility

- No argument-spec or return-value changes are reported.
- Added public OIDC helper methods in `plugins/module_utils/oidc_auth.py`.
- Username/password authentication no longer sends HTTP Basic credentials.
- Username/password authentication now requires a valid OIDC provider and token endpoint.
- Direct Bearer-token and unauthenticated behavior remain unchanged.
- Missing `jsonschema` or PyYAML no longer affects configurations that do not load a configuration file.
- Existing deployments that rely on Basic authentication must provide compatible OIDC configuration. Otherwise, authentication fails instead of silently using Basic credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->