### PR TITLE
EDM-4979: defer jsonschema/pyyaml import checks to _load_config_file

### DIFF
--- a/plugins/module_utils/config_loader.py
+++ b/plugins/module_utils/config_loader.py
@@ -25,11 +25,6 @@ from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 
 class ConfigLoader:
     def __init__(self, config_file=None, warn_callback=None):
-        if JSONSCHEMA_IMPORT_ERROR:
-            raise JSONSCHEMA_IMPORT_ERROR
-        if PYYAML_IMPORT_ERROR:
-            raise PYYAML_IMPORT_ERROR
-
         self._warn_callback = warn_callback
 
         # Assign token from config if it exists
@@ -44,6 +39,17 @@ class ConfigLoader:
 
     def _load_config_file(self, config_file):
         """Loads and validates the configuration from the provided file."""
+        if PYYAML_IMPORT_ERROR:
+            raise ImportError(
+                "The 'pyyaml' package is required when using a config file. "
+                "Install it with: pip install pyyaml"
+            ) from PYYAML_IMPORT_ERROR
+        if JSONSCHEMA_IMPORT_ERROR:
+            raise ImportError(
+                "The 'jsonschema' package is required when using a config file. "
+                "Install it with: pip install jsonschema"
+            ) from JSONSCHEMA_IMPORT_ERROR
+
         # Define the schema for validation
         schema = {
             "type": "object",

--- a/tests/unit/plugins/module_utils/test_config_loader.py
+++ b/tests/unit/plugins/module_utils/test_config_loader.py
@@ -1,0 +1,102 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import os
+from unittest import mock
+
+import pytest
+
+from plugins.module_utils.config_loader import ConfigLoader
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestConfigLoaderNoConfigFile:
+    """ConfigLoader must succeed without jsonschema/pyyaml when config_file=None."""
+
+    def test_init_without_config_file(self):
+        loader = ConfigLoader(config_file=None)
+        assert loader is not None
+
+    def test_init_without_config_file_no_jsonschema(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {"JSONSCHEMA_IMPORT_ERROR": ImportError("No module named 'jsonschema'")},
+        ):
+            loader = ConfigLoader(config_file=None)
+            assert loader is not None
+
+    def test_init_without_config_file_no_pyyaml(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {"PYYAML_IMPORT_ERROR": ImportError("No module named 'yaml'")},
+        ):
+            loader = ConfigLoader(config_file=None)
+            assert loader is not None
+
+    def test_init_without_config_file_no_both(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {
+                "JSONSCHEMA_IMPORT_ERROR": ImportError("No module named 'jsonschema'"),
+                "PYYAML_IMPORT_ERROR": ImportError("No module named 'yaml'"),
+            },
+        ):
+            loader = ConfigLoader(config_file=None)
+            assert loader is not None
+
+
+class TestConfigLoaderMissingDependencies:
+    """ConfigLoader must raise actionable ImportError when config_file is set but deps are missing."""
+
+    def test_missing_jsonschema_raises_actionable_error(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {"JSONSCHEMA_IMPORT_ERROR": ImportError("No module named 'jsonschema'")},
+        ), pytest.raises(ImportError, match="pip install jsonschema"):
+            ConfigLoader(config_file="some/path.yaml")
+
+    def test_missing_pyyaml_raises_actionable_error(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {"PYYAML_IMPORT_ERROR": ImportError("No module named 'yaml'")},
+        ), pytest.raises(ImportError, match="pip install pyyaml"):
+            ConfigLoader(config_file="some/path.yaml")
+
+    def test_missing_pyyaml_checked_before_jsonschema(self):
+        with mock.patch.dict(
+            "plugins.module_utils.config_loader.__dict__",
+            {
+                "JSONSCHEMA_IMPORT_ERROR": ImportError("No module named 'jsonschema'"),
+                "PYYAML_IMPORT_ERROR": ImportError("No module named 'yaml'"),
+            },
+        ), pytest.raises(ImportError, match="pip install pyyaml"):
+            ConfigLoader(config_file="some/path.yaml")
+
+
+class TestConfigLoaderWithConfigFile:
+    """ConfigLoader correctly loads and parses valid config files."""
+
+    def test_load_valid_config_file(self):
+        config_file = os.path.join(FIXTURES_DIR, "client.yaml")
+        loader = ConfigLoader(config_file=config_file)
+        assert loader.host == "https://agent-api.flightctl.127.0.0.1.nip.io:7443"
+        assert loader.organization == "00000000-0000-0000-0000-000000000000"
+
+    def test_load_config_with_ca_data(self):
+        config_file = os.path.join(FIXTURES_DIR, "client_with_ca_data.yaml")
+        loader = ConfigLoader(config_file=config_file)
+        assert loader.host == "https://192.168.86.25.nip.io:3443"
+        assert hasattr(loader, "ca_data")
+
+    def test_load_nonexistent_file_raises(self):
+        with pytest.raises(Exception, match="was not found"):
+            ConfigLoader(config_file="/nonexistent/path.yaml")
+
+    def test_warn_callback_called(self):
+        warnings = []
+        config_file = os.path.join(FIXTURES_DIR, "client.yaml")
+        ConfigLoader(config_file=config_file, warn_callback=warnings.append)
+        # No warnings expected for a valid config with empty auth
+        # Just verify the callback was accepted without error


### PR DESCRIPTION
## Summary

`ConfigLoader.__init__()` unconditionally raised `ImportError` for `jsonschema` and `pyyaml` even when `config_file=None`. These packages are only used inside `_load_config_file()` for YAML parsing and schema validation — they are not needed when no config file is provided.

This fix moves the import error checks from `__init__()` to `_load_config_file()` and adds actionable error messages (e.g., "Install it with: pip install jsonschema").

## Changes

- **`plugins/module_utils/config_loader.py`**: Moved `JSONSCHEMA_IMPORT_ERROR` and `PYYAML_IMPORT_ERROR` checks from `__init__` to `_load_config_file()` with descriptive error messages
- **`tests/unit/plugins/module_utils/test_config_loader.py`** (new): 11 unit tests covering:
  - `ConfigLoader(config_file=None)` succeeds without `jsonschema`/`pyyaml`
  - Actionable `ImportError` when deps are missing and a config file IS provided
  - Valid config file loading with existing fixtures

## Testing

- 11 new unit tests added
- Full unit test suite passes (178 tests, 0 failures)
- Lint checks pass (remaining warnings are pre-existing project-wide patterns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Shared utilities:** Updated `plugins/module_utils/config_loader.py` to defer `jsonschema` and `pyyaml` checks until `_load_config_file()` runs.
- **Plugin behavior:** `ConfigLoader(config_file=None)` now works without these optional dependencies. Configuration loading raises actionable `ImportError` messages with installation instructions.
- **API surface:** No changes to argument specifications, return values, or public declarations.
- **Test coverage:** Added 11 unit tests in `tests/unit/plugins/module_utils/test_config_loader.py` for dependency-free initialization, dependency errors, valid YAML, CA data, missing files, and warning callbacks.
- **CI and metadata:** No changes to CI configuration, collection metadata, integration tests, or other plugin areas.
- **Compatibility:** Callers that initialize `ConfigLoader` without loading a file no longer need `jsonschema` or `pyyaml`. Configuration-file behavior remains unchanged. The full suite passes with 178 tests. Lint checks pass except for pre-existing project-wide warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->