### PR TITLE
EDM-4975: add missing env declarations to inventory plugin connection options

### DIFF
--- a/plugins/inventory/flightctl.py
+++ b/plugins/inventory/flightctl.py
@@ -28,6 +28,8 @@ options:
       description: Path to a CA cert file to use when making requests.
       default: null
       type: path
+      env:
+        - name: FLIGHTCTL_CA_PATH
     ca_data:
       description: CertificateAuthorityData contains PEM-encoded certificate authority certificates.
                            It will be written into a temporary file to enable underlying code to use ca_path.
@@ -38,26 +40,38 @@ options:
                            If `false', SSL certificates will not be validated.
                            This should only be used on personally controlled sites using self-signed certificates.
       type: bool
+      env:
+        - name: FLIGHTCTL_VERIFY_SSL
     host:
       description: URL to Flight Control server. A token or username/password must be also provided.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_HOST
     organization:
       description: Organization to scope Flight Control requests to.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_ORGANIZATION
     username:
       description: Username for your Flight Control service. Please note that this only works with proxies configured to use HTTP Basic Auth.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_USERNAME
     password:
       description: Password for your Flight Control service. Please note that this only works with proxies configured to use HTTP Basic Auth.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_PASSWORD
     token:
       description: The Flight Control API token to use.
       default: null
       type: str
+      env:
+        - name: FLIGHTCTL_TOKEN
     additional_groups:
       description: Additional groups to add devices to.
       type: list
@@ -100,6 +114,8 @@ options:
           C(service.certificate-authority-data) (base64-encoded PEM).
         - Any values defined in the inventory override values from this file.
       type: path
+      env:
+        - name: FLIGHTCTL_CONFIG_FILE
     hostnames:
       description: |
         Dotted path of the device field to use as the Ansible inventory hostname (for example, C(metadata.name) or C(status.systemInfo.hostname)).

--- a/tests/unit/plugins/inventory/test_flightctl.py
+++ b/tests/unit/plugins/inventory/test_flightctl.py
@@ -1,8 +1,17 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+import yaml
 
 # Import your inventory module
-from plugins.inventory.flightctl import InventoryModule, _render_hostname_expression, _resolve_hostname, _validate_device
+from plugins.inventory.flightctl import (
+    DOCUMENTATION,
+    InventoryModule,
+    _render_hostname_expression,
+    _resolve_hostname,
+    _validate_device,
+)
 
 
 class TestFlightCtlInventoryModule(unittest.TestCase):
@@ -519,6 +528,78 @@ class TestValidateDeviceWithExpressions(unittest.TestCase):
         device_id, metadata = _validate_device(device, "metadata.name + '_' + metadata.uid")
         self.assertEqual(device_id, 'device1_')
         self.assertEqual(metadata, device['metadata'])
+
+
+class TestDocumentationEnvDeclarations(unittest.TestCase):
+    """Verify that all connection options declare env: blocks for AAP Credential Type support."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = yaml.safe_load(DOCUMENTATION)
+        cls.options = cls.doc.get('options', {})
+
+    EXPECTED_ENV_VARS: ClassVar[dict[str, str]] = {
+        'token': 'FLIGHTCTL_TOKEN',
+        'host': 'FLIGHTCTL_HOST',
+        'username': 'FLIGHTCTL_USERNAME',
+        'password': 'FLIGHTCTL_PASSWORD',
+        'organization': 'FLIGHTCTL_ORGANIZATION',
+        'flightctl_config_file': 'FLIGHTCTL_CONFIG_FILE',
+        'ca_path': 'FLIGHTCTL_CA_PATH',
+        'verify_ssl': 'FLIGHTCTL_VERIFY_SSL',
+    }
+
+    def test_all_connection_options_have_env_declarations(self):
+        """Every connection option must have an env: block with the correct variable name."""
+        for option_name, expected_env in self.EXPECTED_ENV_VARS.items():
+            with self.subTest(option=option_name):
+                option = self.options.get(option_name)
+                self.assertIsNotNone(option, f"Option '{option_name}' missing from DOCUMENTATION")
+                env_list = option.get('env')
+                self.assertIsNotNone(env_list, f"Option '{option_name}' is missing env: declaration")
+                self.assertIsInstance(env_list, list)
+                env_names = [e.get('name') for e in env_list]
+                self.assertIn(expected_env, env_names,
+                              f"Option '{option_name}' should declare env var '{expected_env}', got {env_names}")
+
+    def test_token_env_declaration(self):
+        env_list = self.options['token'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_TOKEN')
+
+    def test_host_env_declaration(self):
+        env_list = self.options['host'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_HOST')
+
+    def test_username_env_declaration(self):
+        env_list = self.options['username'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_USERNAME')
+
+    def test_password_env_declaration(self):
+        env_list = self.options['password'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_PASSWORD')
+
+    def test_organization_env_declaration(self):
+        env_list = self.options['organization'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_ORGANIZATION')
+
+    def test_config_file_env_declaration(self):
+        env_list = self.options['flightctl_config_file'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_CONFIG_FILE')
+
+    def test_ca_path_env_declaration(self):
+        env_list = self.options['ca_path'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_CA_PATH')
+
+    def test_verify_ssl_env_declaration(self):
+        env_list = self.options['verify_ssl'].get('env', [])
+        self.assertEqual(env_list[0]['name'], 'FLIGHTCTL_VERIFY_SSL')
+
+    def test_env_vars_match_module_utils_convention(self):
+        """Env var names must follow the FLIGHTCTL_ prefix convention used in module_utils/core.py."""
+        for option_name, expected_env in self.EXPECTED_ENV_VARS.items():
+            with self.subTest(option=option_name):
+                self.assertTrue(expected_env.startswith('FLIGHTCTL_'),
+                                f"Env var '{expected_env}' should start with FLIGHTCTL_")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- The `flightctl` inventory plugin's DOCUMENTATION block was missing `env:` declarations for all 8 connection options (`token`, `host`, `username`, `password`, `organization`, `flightctl_config_file`, `ca_path`, `verify_ssl`)
- This caused Ansible's `get_option()` to silently ignore environment variables like `FLIGHTCTL_TOKEN`, making AAP Credential Type injection non-functional
- Added `env:` declarations for all 8 options and comprehensive tests verifying the DOCUMENTATION metadata

## Root Cause

Ansible inventory plugins use the `env:` key in their DOCUMENTATION YAML to tell `get_option()` which environment variables to check. Without these declarations, environment variables are never read. The connection plugin (`flightctl_console.py`) and module_utils (`core.py`) in the same collection correctly declare these env vars — only the inventory plugin was missing them.

## Changes

- `plugins/inventory/flightctl.py` — Added `env:` blocks to DOCUMENTATION for all 8 connection options
- `tests/unit/plugins/inventory/test_flightctl.py` — Added `TestDocumentationEnvDeclarations` class with 10 tests (16 subtests)

No Python logic changes — purely declarative metadata fix.

## Test plan

- [x] 10 new unit tests verifying DOCUMENTATION env declarations pass
- [x] Full test suite passes (188 tests, 0 failures)
- [x] Lint clean (no new issues)
- [ ] Manual verification: set `FLIGHTCTL_TOKEN`/`FLIGHTCTL_HOST` as env vars and run inventory plugin without those values in YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)