### PR TITLE
Release v1.6.1: inventory plugin bug fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ flightctl collection Release Notes
 
 .. contents:: Topics
 
+v1.6.1
+======
+
+Release Summary
+---------------
+
+Bug fix release addressing inventory plugin crashes and authentication issues.
+
+Bugfixes
+--------
+
+- Deferred ``jsonschema`` and ``pyyaml`` import checks in ``ConfigLoader`` to ``_load_config_file()`` so that the inventory plugin no longer raises ``ImportError`` when these packages are absent and no config file is used.
+- Added missing ``env`` declarations to all inventory plugin connection options so that environment variables (``FLIGHTCTL_TOKEN``, ``FLIGHTCTL_HOST``, etc.) are no longer silently ignored by ``get_option()``, restoring AAP Credential Type injection support.
+- Replaced broken HTTP Basic Auth with an OIDC Resource Owner Password Grant flow in the inventory plugin, matching the ``flightctl`` CLI behavior and fixing authentication against RHEM servers that only accept Bearer tokens.
+- Added a pydantic ``ValidationError`` fallback in the inventory plugin that retries device list calls using raw JSON endpoints, fixing crashes when the API returns mount-only application volumes without the required ``image`` field.
+
 v1.6.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -143,3 +143,25 @@ releases:
     fragments:
       - flightctl_1.6.0_update.yml
     release_date: '2026-06-22'
+  1.6.1:
+    changes:
+      bugfixes:
+        - Deferred ``jsonschema`` and ``pyyaml`` import checks in ``ConfigLoader``
+          to ``_load_config_file()`` so that the inventory plugin no longer raises
+          ``ImportError`` when these packages are absent and no config file is used.
+        - Added missing ``env`` declarations to all inventory plugin connection options
+          so that environment variables (``FLIGHTCTL_TOKEN``, ``FLIGHTCTL_HOST``, etc.)
+          are no longer silently ignored by ``get_option()``, restoring AAP Credential
+          Type injection support.
+        - Replaced broken HTTP Basic Auth with an OIDC Resource Owner Password Grant
+          flow in the inventory plugin, matching the ``flightctl`` CLI behavior and
+          fixing authentication against RHEM servers that only accept Bearer tokens.
+        - Added a pydantic ``ValidationError`` fallback in the inventory plugin that
+          retries device list calls using raw JSON endpoints, fixing crashes when the
+          API returns mount-only application volumes without the required ``image``
+          field.
+      release_summary: Bug fix release addressing inventory plugin crashes and authentication
+        issues.
+    fragments:
+      - flightctl_1.6.1_bugfixes.yml
+    release_date: '2026-08-13'

--- a/changelogs/fragments/flightctl_1.6.1_bugfixes.yml
+++ b/changelogs/fragments/flightctl_1.6.1_bugfixes.yml
@@ -1,0 +1,22 @@
+release_summary: >-
+  Bug fix release addressing inventory plugin crashes and authentication issues.
+
+bugfixes:
+  - >-
+    Deferred ``jsonschema`` and ``pyyaml`` import checks in ``ConfigLoader`` to
+    ``_load_config_file()`` so that the inventory plugin no longer raises
+    ``ImportError`` when these packages are absent and no config file is used.
+  - >-
+    Added missing ``env`` declarations to all inventory plugin connection options
+    so that environment variables (``FLIGHTCTL_TOKEN``, ``FLIGHTCTL_HOST``, etc.)
+    are no longer silently ignored by ``get_option()``, restoring AAP Credential
+    Type injection support.
+  - >-
+    Replaced broken HTTP Basic Auth with an OIDC Resource Owner Password Grant
+    flow in the inventory plugin, matching the ``flightctl`` CLI behavior and
+    fixing authentication against RHEM servers that only accept Bearer tokens.
+  - >-
+    Added a pydantic ``ValidationError`` fallback in the inventory plugin that
+    retries device list calls using raw JSON endpoints, fixing crashes when the
+    API returns mount-only application volumes without the required ``image``
+    field.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -71,7 +71,14 @@ build_ignore:
   - ".config"
   - ".ruff*"
   - ".tox*"
-  - "ci/"
+  - "ci"
+  - "tests/integration/integration_config.yml"
+  - "tox.ini"
+  - "pyproject.toml"
+  - "CHANGELOG.md"
+  - "*.tar.gz"
+  - ".*"
+  - "*/.*"
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: flightctl
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.6.0
+version: 1.6.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Summary
- Bumps collection version to **1.6.1** and adds changelog entries for all bug fixes since v1.6.0
- **EDM-4979**: Deferred `jsonschema`/`pyyaml` import checks to `_load_config_file()` to prevent `ImportError` when no config file is used
- **EDM-4975**: Added missing `env` declarations to inventory plugin connection options, restoring AAP Credential Type injection
- **EDM-4977**: Replaced broken HTTP Basic Auth with OIDC Resource Owner Password Grant flow in the inventory plugin
- **EDM-4980**: Added pydantic `ValidationError` fallback for mount-only application volumes without the `image` field

## Test plan
- [ ] Verify `galaxy.yml` version is `1.6.1`
- [ ] Verify `CHANGELOG.rst` contains the new v1.6.1 section with all four bug fixes
- [ ] Verify `changelogs/changelog.yaml` has the 1.6.1 release entry
- [ ] Run `ansible-test sanity` to ensure no lint issues
- [ ] Run unit tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated collection metadata to version `1.6.1` in `galaxy.yml`.
- Added release notes to `CHANGELOG.rst`, `changelogs/changelog.yaml`, and the release fragment.
- Fixed inventory plugin behavior:
  - Deferred `jsonschema` and `pyyaml` import checks until `_load_config_file()` runs.
  - Added missing `env` declarations to connection options.
  - Replaced HTTP Basic Auth with the OIDC Resource Owner Password Grant flow.
  - Added a `pydantic.ValidationError` fallback for mount-only application volumes without an `image` field.

## Impact

- Affects `plugins/inventory/` and related shared plugin behavior.
- No module argument-spec or return-value changes are reported.
- No changes affect `plugins/modules/`, `plugins/connection/`, `plugins/doc_fragments/`, tests, CI, or demo files.
- The collection metadata and changelog files changed.

## Compatibility and security

- Existing inventory configuration that depends on optional `jsonschema` or `pyyaml` imports can now load until `_load_config_file()` requires those dependencies.
- Inventory authentication now uses OIDC bearer tokens instead of HTTP Basic Auth.
- The authentication change may require updated credentials or identity-provider configuration.
- The fallback prevents validation failures for mount-only volumes and preserves support for API responses without required `image` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->