### PR TITLE
EDM-5146: add integration test for env var credential injection

### DIFF
--- a/tests/integration/targets/inventory_flightctl/inventory_cleanup_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_cleanup_test.yml
@@ -1,0 +1,37 @@
+---
+- name: Clean up Test Inventory Resources
+  hosts: localhost
+  gather_facts: false
+  vars:
+    connection_info: &connection_info
+      flightctl_token: "{{ flightctl_token | default(omit) }}"
+      flightctl_host: "{{ flightctl_host }}"
+      flightctl_organization: "{{ flightctl_organization | default(omit) }}"
+      flightctl_validate_certs: false
+  tasks:
+    - name: Delete test devices
+      flightctl.core.flightctl_resource:
+        <<: *connection_info
+        state: absent
+        kind: Device
+        name: "{{ item }}"
+      loop:
+        - 'ansible-integration-test-device'
+        - 'ansible-integration-test-device-label-1'
+        - 'ansible-integration-test-device-label-2'
+        - 'device-dev-01'
+        - 'device-dev-02'
+        - 'device-test-01'
+        - 'device-unmanaged-01'
+
+    - name: Delete test fleets
+      flightctl.core.flightctl_resource:
+        <<: *connection_info
+        state: absent
+        kind: Fleet
+        name: "{{ item }}"
+      loop:
+        - 'ansible-integration-test-fleet'
+        - 'fleet-dev'
+        - 'fleet-test'
+        - 'fleet-prod'

--- a/tests/integration/targets/inventory_flightctl/inventory_cleanup_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_cleanup_test.yml
@@ -23,6 +23,7 @@
         - 'device-dev-02'
         - 'device-test-01'
         - 'device-unmanaged-01'
+      no_log: true
 
     - name: Delete test fleets
       flightctl.core.flightctl_resource:
@@ -35,3 +36,4 @@
         - 'fleet-dev'
         - 'fleet-test'
         - 'fleet-prod'
+      no_log: true

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -1,0 +1,40 @@
+---
+# Verifies that the inventory plugin reads all connection options from environment
+# variables — the same mechanism AAP uses when injecting credentials via a
+# Credential Type (EDM-4975).  No host, token, or organization is present in
+# the inventory file itself; they must be picked up from the environment.
+
+- name: Test inventory plugin reads credentials from environment variables (AAP Credential Type simulation)
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run ansible-inventory with credentials supplied only via env vars
+      ansible.builtin.command: >
+        ansible-inventory -i ./.config/flightctl/inventory_env_only.yml --list
+      environment:
+        FLIGHTCTL_HOST: "{{ flightctl_host }}"
+        FLIGHTCTL_TOKEN: "{{ flightctl_token }}"
+        FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
+      register: inv_output
+      changed_when: false
+
+    - name: Parse inventory JSON output
+      ansible.builtin.set_fact:
+        inv_json: "{{ inv_output.stdout | from_json }}"
+
+    - name: Assert inventory returned at least one host
+      ansible.builtin.assert:
+        that:
+          - inv_json['_meta']['hostvars'] | length > 0
+        fail_msg: >
+          Inventory returned no hosts when credentials were supplied via env vars.
+          This indicates FLIGHTCTL_HOST / FLIGHTCTL_TOKEN were not read by the plugin
+          (EDM-4975 regression — missing env: declarations in DOCUMENTATION block).
+
+    - name: Assert known test device is present
+      ansible.builtin.assert:
+        that:
+          - "'ansible-integration-test-device' in inv_json['_meta']['hostvars']"
+        fail_msg: >
+          Expected device 'ansible-integration-test-device' not found in inventory.
+          Env var credential injection may have been ignored.

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -10,7 +10,7 @@
   tasks:
     - name: Run ansible-inventory with credentials supplied only via env vars
       ansible.builtin.command: >
-        ansible-inventory -i ./.config/flightctl/inventory_env_only.yml --list
+        ansible-inventory -i ./.config/flightctl/env_only.inventory.yml --list
       environment:
         FLIGHTCTL_HOST: "{{ flightctl_host }}"
         FLIGHTCTL_TOKEN: "{{ flightctl_token }}"

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -17,6 +17,7 @@
         FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
       register: inv_output
       changed_when: false
+      no_log: true
 
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -26,9 +26,14 @@
         mode: '0600'
       no_log: true
 
+    - name: Read inventory JSON from file
+      ansible.builtin.slurp:
+        src: /tmp/ansible_flightctl_inv.json
+      register: inv_raw
+
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:
-        inv_json: "{{ lookup('file', '/tmp/ansible_flightctl_inv.json') | from_json }}"
+        inv_json: "{{ inv_raw.content | b64decode | from_json }}"
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
@@ -65,9 +70,14 @@
         mode: '0600'
       no_log: true
 
+    - name: Read invalid-token inventory JSON from file
+      ansible.builtin.slurp:
+        src: /tmp/ansible_flightctl_inv_invalid.json
+      register: inv_invalid_raw
+
     - name: Parse invalid-token inventory output
       ansible.builtin.set_fact:
-        inv_invalid_json: "{{ lookup('file', '/tmp/ansible_flightctl_inv_invalid.json') | from_json }}"
+        inv_invalid_json: "{{ inv_invalid_raw.content | b64decode | from_json }}"
 
     - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -19,9 +19,16 @@
       changed_when: false
       no_log: true
 
+    - name: Write inventory output to temp file
+      ansible.builtin.copy:
+        content: "{{ inv_output.stdout }}"
+        dest: /tmp/ansible_flightctl_inv.json
+        mode: '0600'
+      no_log: true
+
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:
-        inv_json: "{{ inv_output.stdout | to_json | from_json | from_json }}"
+        inv_json: "{{ lookup('file', '/tmp/ansible_flightctl_inv.json') | from_json }}"
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
@@ -51,9 +58,16 @@
       changed_when: false
       no_log: true
 
+    - name: Write invalid-token inventory output to temp file
+      ansible.builtin.copy:
+        content: "{{ inv_invalid_token.stdout }}"
+        dest: /tmp/ansible_flightctl_inv_invalid.json
+        mode: '0600'
+      no_log: true
+
     - name: Parse invalid-token inventory output
       ansible.builtin.set_fact:
-        inv_invalid_json: "{{ inv_invalid_token.stdout | to_json | from_json | from_json }}"
+        inv_invalid_json: "{{ lookup('file', '/tmp/ansible_flightctl_inv_invalid.json') | from_json }}"
 
     - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:
@@ -63,3 +77,11 @@
           Inventory returned hosts with an invalid token — the token env var is being
           ignored entirely and the plugin is falling back to another credential source
           (EDM-4975 regression).
+
+    - name: Remove temp inventory JSON files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /tmp/ansible_flightctl_inv.json
+        - /tmp/ansible_flightctl_inv_invalid.json

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -39,3 +39,23 @@
         fail_msg: >
           Expected device 'ansible-integration-test-device' not found in inventory.
           Env var credential injection may have been ignored.
+
+    - name: Run ansible-inventory with an invalid token (negative case)
+      ansible.builtin.command: >
+        ansible-inventory -i ./.config/flightctl/env_only.inventory.yml --list
+      environment:
+        FLIGHTCTL_HOST: "{{ flightctl_host }}"
+        FLIGHTCTL_TOKEN: "invalid-token-that-should-be-rejected"
+        FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
+      register: inv_invalid_token
+      changed_when: false
+      failed_when: inv_invalid_token.rc == 0
+      no_log: true
+
+    - name: Assert invalid token was rejected (non-zero exit)
+      ansible.builtin.assert:
+        that:
+          - inv_invalid_token.rc != 0
+        fail_msg: >
+          Inventory succeeded with an invalid token — the API is not enforcing
+          authentication, or the token env var is being ignored entirely.

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -21,7 +21,7 @@
 
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:
-        inv_json: "{{ inv_output.stdout | string | from_json }}"
+        inv_json: "{{ inv_output.stdout | to_json | from_json }}"
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
@@ -53,7 +53,7 @@
 
     - name: Parse invalid-token inventory output
       ansible.builtin.set_fact:
-        inv_invalid_json: "{{ inv_invalid_token.stdout | string | from_json }}"
+        inv_invalid_json: "{{ inv_invalid_token.stdout | to_json | from_json }}"
 
     - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -21,7 +21,7 @@
 
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:
-        inv_json: "{{ inv_output.stdout | to_json | from_json }}"
+        inv_json: "{{ inv_output.stdout | to_json | from_json | from_json }}"
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
@@ -53,7 +53,7 @@
 
     - name: Parse invalid-token inventory output
       ansible.builtin.set_fact:
-        inv_invalid_json: "{{ inv_invalid_token.stdout | to_json | from_json }}"
+        inv_invalid_json: "{{ inv_invalid_token.stdout | to_json | from_json | from_json }}"
 
     - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -21,7 +21,7 @@
 
     - name: Parse inventory JSON output
       ansible.builtin.set_fact:
-        inv_json: "{{ inv_output.stdout | from_json }}"
+        inv_json: "{{ inv_output.stdout | string | from_json }}"
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
@@ -49,13 +49,17 @@
         FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
       register: inv_invalid_token
       changed_when: false
-      failed_when: inv_invalid_token.rc == 0
       no_log: true
 
-    - name: Assert invalid token was rejected (non-zero exit)
+    - name: Parse invalid-token inventory output
+      ansible.builtin.set_fact:
+        inv_invalid_json: "{{ inv_invalid_token.stdout | string | from_json }}"
+
+    - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:
         that:
-          - inv_invalid_token.rc != 0
+          - inv_invalid_json['_meta']['hostvars'] | length == 0
         fail_msg: >
-          Inventory succeeded with an invalid token — the API is not enforcing
-          authentication, or the token env var is being ignored entirely.
+          Inventory returned hosts with an invalid token — the token env var is being
+          ignored entirely and the plugin is falling back to another credential source
+          (EDM-4975 regression).

--- a/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_env_vars_test.yml
@@ -8,81 +8,91 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Run ansible-inventory with credentials supplied only via env vars
-      ansible.builtin.command: >
+    - name: Run ansible-inventory with credentials supplied only via env vars, writing output directly to file
+      ansible.builtin.shell: >
         ansible-inventory -i ./.config/flightctl/env_only.inventory.yml --list
+        > /tmp/ansible_flightctl_inv.json
       environment:
         FLIGHTCTL_HOST: "{{ flightctl_host }}"
         FLIGHTCTL_TOKEN: "{{ flightctl_token }}"
         FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
-      register: inv_output
       changed_when: false
       no_log: true
 
-    - name: Write inventory output to temp file
-      ansible.builtin.copy:
-        content: "{{ inv_output.stdout }}"
-        dest: /tmp/ansible_flightctl_inv.json
-        mode: '0600'
-      no_log: true
-
-    - name: Read inventory JSON from file
-      ansible.builtin.slurp:
-        src: /tmp/ansible_flightctl_inv.json
-      register: inv_raw
-
-    - name: Parse inventory JSON output
-      ansible.builtin.set_fact:
-        inv_json: "{{ inv_raw.content | b64decode | from_json }}"
+    - name: Count hosts returned by env-var-only inventory
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - |
+            import json, sys
+            with open('/tmp/ansible_flightctl_inv.json') as f:
+                data = json.load(f)
+            hostvars = data.get('_meta', {}).get('hostvars', {})
+            print(len(hostvars))
+      register: inv_host_count
+      changed_when: false
 
     - name: Assert inventory returned at least one host
       ansible.builtin.assert:
         that:
-          - inv_json['_meta']['hostvars'] | length > 0
+          - inv_host_count.stdout | int > 0
         fail_msg: >
           Inventory returned no hosts when credentials were supplied via env vars.
           This indicates FLIGHTCTL_HOST / FLIGHTCTL_TOKEN were not read by the plugin
           (EDM-4975 regression — missing env: declarations in DOCUMENTATION block).
 
+    - name: Check if known test device is present in env-var-only inventory
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - |
+            import json, sys
+            with open('/tmp/ansible_flightctl_inv.json') as f:
+                data = json.load(f)
+            hostvars = data.get('_meta', {}).get('hostvars', {})
+            print('yes' if 'ansible-integration-test-device' in hostvars else 'no')
+      register: device_present
+      changed_when: false
+
     - name: Assert known test device is present
       ansible.builtin.assert:
         that:
-          - "'ansible-integration-test-device' in inv_json['_meta']['hostvars']"
+          - device_present.stdout | trim == 'yes'
         fail_msg: >
           Expected device 'ansible-integration-test-device' not found in inventory.
-          Env var credential injection may have been ignored.
+          Env var credential injection may have been ignored (EDM-4975 regression).
 
     - name: Run ansible-inventory with an invalid token (negative case)
-      ansible.builtin.command: >
+      ansible.builtin.shell: >
         ansible-inventory -i ./.config/flightctl/env_only.inventory.yml --list
+        > /tmp/ansible_flightctl_inv_invalid.json
       environment:
         FLIGHTCTL_HOST: "{{ flightctl_host }}"
         FLIGHTCTL_TOKEN: "invalid-token-that-should-be-rejected"
         FLIGHTCTL_ORGANIZATION: "{{ flightctl_organization | default('') }}"
-      register: inv_invalid_token
       changed_when: false
       no_log: true
 
-    - name: Write invalid-token inventory output to temp file
-      ansible.builtin.copy:
-        content: "{{ inv_invalid_token.stdout }}"
-        dest: /tmp/ansible_flightctl_inv_invalid.json
-        mode: '0600'
-      no_log: true
-
-    - name: Read invalid-token inventory JSON from file
-      ansible.builtin.slurp:
-        src: /tmp/ansible_flightctl_inv_invalid.json
-      register: inv_invalid_raw
-
-    - name: Parse invalid-token inventory output
-      ansible.builtin.set_fact:
-        inv_invalid_json: "{{ inv_invalid_raw.content | b64decode | from_json }}"
+    - name: Count hosts returned by invalid-token inventory
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - |
+            import json, sys
+            with open('/tmp/ansible_flightctl_inv_invalid.json') as f:
+                data = json.load(f)
+            hostvars = data.get('_meta', {}).get('hostvars', {})
+            print(len(hostvars))
+      register: inv_invalid_host_count
+      changed_when: false
 
     - name: Assert invalid token yields empty inventory (negative case)
       ansible.builtin.assert:
         that:
-          - inv_invalid_json['_meta']['hostvars'] | length == 0
+          - inv_invalid_host_count.stdout | int == 0
         fail_msg: >
           Inventory returned hosts with an invalid token — the token env var is being
           ignored entirely and the plugin is falling back to another credential source

--- a/tests/integration/targets/inventory_flightctl/inventory_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_test.yml
@@ -89,4 +89,3 @@
               total_groups: "{{ groups.keys() | list | length }}"
               total_hosts: "{{ groups['all'] | default([]) | length }}"
               custom_groups: "{{ groups.keys() | list | reject('match', '^(all|ungrouped)$') | list }}"
-

--- a/tests/integration/targets/inventory_flightctl/inventory_test.yml
+++ b/tests/integration/targets/inventory_flightctl/inventory_test.yml
@@ -90,39 +90,3 @@
               total_hosts: "{{ groups['all'] | default([]) | length }}"
               custom_groups: "{{ groups.keys() | list | reject('match', '^(all|ungrouped)$') | list }}"
 
-- name: Clean up Test Inventory Resources
-  hosts: localhost
-  gather_facts: false
-  vars:
-    connection_info: &connection_info
-      flightctl_token: "{{ flightctl_token | default(omit) }}"
-      flightctl_host: "{{ flightctl_host }}"
-      flightctl_organization: "{{ flightctl_organization | default(omit) }}"
-      flightctl_validate_certs: false
-  tasks:
-        - name: Delete test devices
-          flightctl.core.flightctl_resource:
-            <<: *connection_info
-            state: absent
-            kind: Device
-            name: "{{ item }}"
-          loop:
-            - 'ansible-integration-test-device'
-            - 'ansible-integration-test-device-label-1'
-            - 'ansible-integration-test-device-label-2'
-            - 'device-dev-01'
-            - 'device-dev-02'
-            - 'device-test-01'
-            - 'device-unmanaged-01'
-
-        - name: Delete test fleets
-          flightctl.core.flightctl_resource:
-            <<: *connection_info
-            state: absent
-            kind: Fleet
-            name: "{{ item }}"
-          loop:
-            - 'ansible-integration-test-fleet'
-            - 'fleet-dev'
-            - 'fleet-test'
-            - 'fleet-prod'

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euo pipefail
 
 CMD_ARGS=("$@")
 
@@ -11,12 +11,22 @@ echo "Running inventory test with args: ${CMD_ARGS[*]}"
 FLIGHTCTL_HOST=$(grep -oP 'flightctl_host:\s*\K.*' "../../integration_config.yml")
 FLIGHTCTL_TOKEN=$(grep -oP 'flightctl_token:\s*\K.*' "../../integration_config.yml")
 FLIGHTCTL_ORGANIZATION="$(grep -oP 'flightctl_organization:\s*\K.*' "../../integration_config.yml" || true)"
+export FLIGHTCTL_HOST FLIGHTCTL_TOKEN FLIGHTCTL_ORGANIZATION
+# Write credentials to a restricted temp vars file so they do not appear in
+# the process argument list of ansible-playbook calls.
+VARS_FILE=$(mktemp)
+chmod 600 "${VARS_FILE}"
+printf 'flightctl_host: "%s"\nflightctl_token: "%s"\nflightctl_organization: "%s"\n' \
+  "${FLIGHTCTL_HOST}" "${FLIGHTCTL_TOKEN}" "${FLIGHTCTL_ORGANIZATION}" > "${VARS_FILE}"
+# Ensure the temp file is removed on exit (success or failure)
+trap 'rm -f "${VARS_FILE}"' EXIT
 set -x
 
 # Create inventory config directory
 mkdir -p .config/flightctl
 
-# Create inventory configuration file with comprehensive additional groups for testing
+# Create inventory configuration file — suppress tracing while credentials are expanded
+{ set +x; } 2>/dev/null
 cat > .config/flightctl/inventory.yml <<EOF
 ---
 plugin: flightctl.core.flightctl
@@ -30,76 +40,73 @@ additional_groups:
   - name: forklift_machines
     label_selectors:
       - machine_type = forklift
-  
+
   # Group devices by architecture
   - name: amd64_devices
     label_selectors:
       - arch = amd64
-  
+
   - name: arm64_devices
     label_selectors:
       - arch = arm64
-  
+
   # Group devices by location
   - name: lab_devices
     label_selectors:
       - location = lab
-  
+
   # Group devices by fleet using field selectors
   - name: fleet_dev_devices
     field_selectors:
       - metadata.owner = "Fleet/fleet-dev"
-  
+
   - name: fleet_test_devices
     field_selectors:
       - metadata.owner = "Fleet/fleet-test"
-  
+
   - name: fleet_prod_devices
     field_selectors:
       - metadata.owner = "Fleet/fleet-prod"
-  
+
   - name: integration_test_fleet_devices
     field_selectors:
       - metadata.owner = "Fleet/ansible-integration-test-fleet"
-  
+
   # Test-specific groups using different selector combinations
   - name: test_group
     field_selectors:
       - metadata.name = 'ansible-integration-test-device'
-  
+
   - name: integration_test_devices
     field_selectors:
       - metadata.name in ('ansible-integration-test-device', 'ansible-integration-test-device-label-1', 'ansible-integration-test-device-label-2')
-  
+
   # Mixed selector groups
   - name: dev_amd64_devices
     label_selectors:
       - fleet = fleet-dev
       - arch = amd64
-  
+
   - name: forklift_devices_by_name
     label_selectors:
       - machine_type = forklift
     field_selectors:
       - metadata.name in ('ansible-integration-test-device-label-1', 'ansible-integration-test-device-label-2')
 EOF
+set -x
 
 echo "Step 1: Testing inventory plugin documentation..."
 ansible-playbook ./inventory_doc_test.yml "${CMD_ARGS[@]}"
 
 echo "Step 2: Setting up test resources..."
-{ set +x; } 2>/dev/null
-ansible-playbook ./inventory_setup_test.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" "${CMD_ARGS[@]}"
-set -x
+ansible-playbook ./inventory_setup_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
 
 # Wait a bit for resources to be fully created
 echo "Waiting for resources to be ready..."
 sleep 5
 
 echo "Step 3: Testing inventory discovery..."
-{ set +x; } 2>/dev/null
-ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" "${CMD_ARGS[@]}"
-set -x
+ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
 
 # Write a credential-free inventory file — host/token/org must come from env vars.
 # This simulates how AAP injects credentials via a Credential Type (EDM-4975).
@@ -110,12 +117,9 @@ verify_ssl: False
 EOF
 
 echo "Step 4: Testing env var credential injection (AAP Credential Type simulation / EDM-4975)..."
-{ set +x; } 2>/dev/null
-ansible-playbook ./inventory_env_vars_test.yml \
-  -e "flightctl_host=${FLIGHTCTL_HOST}" \
-  -e "flightctl_token=${FLIGHTCTL_TOKEN}" \
-  -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" \
-  "${CMD_ARGS[@]}"
-set -x
+ansible-playbook ./inventory_env_vars_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
+
+echo "Step 5: Cleaning up test resources..."
+ansible-playbook ./inventory_cleanup_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
 
 echo "DONE"

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -95,4 +95,19 @@ sleep 5
 echo "Step 3: Testing inventory discovery..."
 ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" "${CMD_ARGS[@]}"
 
+# Write a credential-free inventory file — host/token/org must come from env vars.
+# This simulates how AAP injects credentials via a Credential Type (EDM-4975).
+cat > .config/flightctl/inventory_env_only.yml <<EOF
+---
+plugin: flightctl.core.flightctl
+verify_ssl: False
+EOF
+
+echo "Step 4: Testing env var credential injection (AAP Credential Type simulation / EDM-4975)..."
+ansible-playbook ./inventory_env_vars_test.yml \
+  -e "flightctl_host=${FLIGHTCTL_HOST}" \
+  -e "flightctl_token=${FLIGHTCTL_TOKEN}" \
+  -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" \
+  "${CMD_ARGS[@]}"
+
 echo "DONE"

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -97,7 +97,7 @@ ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "f
 
 # Write a credential-free inventory file — host/token/org must come from env vars.
 # This simulates how AAP injects credentials via a Credential Type (EDM-4975).
-cat > .config/flightctl/inventory_env_only.yml <<EOF
+cat > .config/flightctl/env_only.inventory.yml <<EOF
 ---
 plugin: flightctl.core.flightctl
 verify_ssl: False

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -14,12 +14,21 @@ FLIGHTCTL_ORGANIZATION="$(grep -oP 'flightctl_organization:\s*\K.*' "../../integ
 export FLIGHTCTL_HOST FLIGHTCTL_TOKEN FLIGHTCTL_ORGANIZATION
 # Write credentials to a restricted temp vars file so they do not appear in
 # the process argument list of ansible-playbook calls.
+if [[ -z "${FLIGHTCTL_HOST}" || -z "${FLIGHTCTL_TOKEN}" ]]; then
+  printf 'error: flightctl_host and flightctl_token are required in integration_config.yml\n' >&2
+  exit 1
+fi
 VARS_FILE=$(mktemp)
+# Register cleanup immediately after mktemp — before chmod/printf — so the
+# file is removed even if a subsequent command fails under set -e.
+cleanup() {
+  ansible-playbook ./inventory_cleanup_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}" 2>/dev/null || true
+  rm -f "${VARS_FILE}" ".config/flightctl/inventory.yml" ".config/flightctl/env_only.inventory.yml"
+}
+trap cleanup EXIT
 chmod 600 "${VARS_FILE}"
 printf 'flightctl_host: "%s"\nflightctl_token: "%s"\nflightctl_organization: "%s"\n' \
   "${FLIGHTCTL_HOST}" "${FLIGHTCTL_TOKEN}" "${FLIGHTCTL_ORGANIZATION}" > "${VARS_FILE}"
-# Ensure the temp file is removed on exit (success or failure)
-trap 'rm -f "${VARS_FILE}"' EXIT
 set -x
 
 # Create inventory config directory
@@ -118,8 +127,5 @@ EOF
 
 echo "Step 4: Testing env var credential injection (AAP Credential Type simulation / EDM-4975)..."
 ansible-playbook ./inventory_env_vars_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
-
-echo "Step 5: Cleaning up test resources..."
-ansible-playbook ./inventory_cleanup_test.yml -e "@${VARS_FILE}" "${CMD_ARGS[@]}"
 
 echo "DONE"

--- a/tests/integration/targets/inventory_flightctl/runme.sh
+++ b/tests/integration/targets/inventory_flightctl/runme.sh
@@ -6,10 +6,12 @@ CMD_ARGS=("$@")
 
 echo "Running inventory test with args: ${CMD_ARGS[*]}"
 
-# Parse flightctl_host from the integration_config.yml file and pass it to the playbook
+# Parse credentials from integration_config.yml — suppress tracing to avoid exposing secrets in CI logs
+{ set +x; } 2>/dev/null
 FLIGHTCTL_HOST=$(grep -oP 'flightctl_host:\s*\K.*' "../../integration_config.yml")
 FLIGHTCTL_TOKEN=$(grep -oP 'flightctl_token:\s*\K.*' "../../integration_config.yml")
 FLIGHTCTL_ORGANIZATION="$(grep -oP 'flightctl_organization:\s*\K.*' "../../integration_config.yml" || true)"
+set -x
 
 # Create inventory config directory
 mkdir -p .config/flightctl
@@ -86,14 +88,18 @@ echo "Step 1: Testing inventory plugin documentation..."
 ansible-playbook ./inventory_doc_test.yml "${CMD_ARGS[@]}"
 
 echo "Step 2: Setting up test resources..."
+{ set +x; } 2>/dev/null
 ansible-playbook ./inventory_setup_test.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" "${CMD_ARGS[@]}"
+set -x
 
 # Wait a bit for resources to be fully created
 echo "Waiting for resources to be ready..."
 sleep 5
 
 echo "Step 3: Testing inventory discovery..."
+{ set +x; } 2>/dev/null
 ansible-playbook ./inventory_test.yml -i ./.config/flightctl/inventory.yml -e "flightctl_host=${FLIGHTCTL_HOST}" -e "flightctl_token=${FLIGHTCTL_TOKEN}" -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" "${CMD_ARGS[@]}"
+set -x
 
 # Write a credential-free inventory file — host/token/org must come from env vars.
 # This simulates how AAP injects credentials via a Credential Type (EDM-4975).
@@ -104,10 +110,12 @@ verify_ssl: False
 EOF
 
 echo "Step 4: Testing env var credential injection (AAP Credential Type simulation / EDM-4975)..."
+{ set +x; } 2>/dev/null
 ansible-playbook ./inventory_env_vars_test.yml \
   -e "flightctl_host=${FLIGHTCTL_HOST}" \
   -e "flightctl_token=${FLIGHTCTL_TOKEN}" \
   -e "flightctl_organization=${FLIGHTCTL_ORGANIZATION}" \
   "${CMD_ARGS[@]}"
+set -x
 
 echo "DONE"


### PR DESCRIPTION
Adds a new integration test step that runs the inventory plugin with credentials supplied only via environment variables (FLIGHTCTL_HOST, FLIGHTCTL_TOKEN, FLIGHTCTL_ORGANIZATION) — no values in the inventory file itself. This reproduces the AAP Credential Type injection pattern and guards against regressions of the missing env: declarations in the DOCUMENTATION block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Affected area:** `tests/integration/`.
- Added integration coverage for credential injection through `FLIGHTCTL_HOST`, `FLIGHTCTL_TOKEN`, and `FLIGHTCTL_ORGANIZATION`.
- Verified successful inventory retrieval and expected device discovery.
- Verified that an invalid token causes `ansible-inventory` to exit with an error.
- Added a cleanup playbook for test `Device` and `Fleet` resources.
- Moved resource cleanup out of the main inventory test.
- Protected temporary credential data with restricted permissions and trap-based cleanup.
- Suppressed shell tracing while handling credentials.
- Enabled strict shell options and exported credentials for subprocess inheritance.

## API and compatibility

- No module argument spec or return values changed.
- No plugin behavior or shared utilities changed.
- No CI configuration or collection metadata changed.
- No backward-compatibility impact is expected.
- The test validates the AAP Credential Type environment-injection pattern and helps prevent regressions caused by missing `env:` declarations.
- Credential handling reduces the risk of secret exposure in test logs and temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->