### PR TITLE
EDM-5200: use OIDC password grant in api_module and imagebuilder_module

### DIFF
--- a/changelogs/fragments/edm-5200-oidc-auth-module-utils.yml
+++ b/changelogs/fragments/edm-5200-oidc-auth-module-utils.yml
@@ -1,0 +1,12 @@
+bugfixes:
+  - >-
+    Replaced broken HTTP Basic Auth with an OIDC Resource Owner Password Grant
+    flow in the shared API module (``module_utils/api_module.py``) and the image
+    builder module (``module_utils/imagebuilder_module.py``). Modules such as
+    ``flightctl_resource``, ``flightctl_resource_info``,
+    ``flightctl_certificate_management``, ``flightctl_enrollment_config_info`` and
+    the image builder modules now authenticate with a Bearer token when given
+    ``username``/``password``, fixing authentication against Flight Control
+    servers that only accept OIDC. This matches the fix previously applied to the
+    inventory plugin. The OIDC discovery and password-grant logic is now shared
+    via ``module_utils/oidc_auth.py``.

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -8,13 +8,13 @@ __metaclass__ = type
 
 import importlib
 from datetime import datetime
-from base64 import b64encode
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
 
 from .constants import API_MAPPING, NESTED_RESOURCES, ResourceType
 from .core import FlightctlModule
 from .exceptions import FlightctlException, FlightctlApiException
+from .oidc_auth import oidc_password_grant
 from .options import ApprovalOptions, GetOptions
 from .utils import diff_dicts, get_patch, json_patch
 
@@ -172,14 +172,19 @@ class FlightctlAPIModule(FlightctlModule):
         """
         Sets auth headers for the underlying client based on set parameters.
 
-        Prioritizes a set token if present on the module.
+        Prioritizes a set token if present on the module. When only
+        username/password are provided, performs an OIDC password grant to obtain
+        a Bearer token (see EDM-5200) — no HTTP Basic Auth is ever sent, matching
+        the inventory plugin's behavior against OIDC-only servers.
         """
         if self.token:
             self.headers = {'Authorization': f'Bearer {self.token}'}
         elif self.username and self.password:
-            basic_credentials = f"{self.username}:{self.password}"
-            encoded_credentials = b64encode(basic_credentials.encode('utf-8')).decode('utf-8')
-            self.headers = {'Authorization': f'Basic {encoded_credentials}'}
+            base_host = self.url.geturl().rstrip('/').removesuffix('/api/v1')
+            token = oidc_password_grant(
+                base_host, self.username, self.password, self.verify_ssl, self.ca_path
+            )
+            self.headers = {'Authorization': f'Bearer {token}'}
         else:
             self.headers = None
 

--- a/plugins/module_utils/imagebuilder_module.py
+++ b/plugins/module_utils/imagebuilder_module.py
@@ -6,11 +6,11 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-from base64 import b64encode
 from typing import Any, Callable, Dict, Optional
 
 from .core import FlightctlModule
 from .exceptions import FlightctlApiException
+from .oidc_auth import oidc_password_grant
 
 try:
     from flightctl.imagebuilder.api_client import ApiClient
@@ -66,12 +66,16 @@ class FlightctlImageBuilderModule(FlightctlModule):
         self._imageexport_api = None
 
     def _set_auth_headers(self) -> None:
+        # When only username/password are provided, perform an OIDC password grant
+        # to obtain a Bearer token (see EDM-5200) — no HTTP Basic Auth is ever sent.
         if self.token:
             self.headers = {'Authorization': f'Bearer {self.token}'}
         elif self.username and self.password:
-            basic_credentials = f"{self.username}:{self.password}"
-            encoded = b64encode(basic_credentials.encode('utf-8')).decode('utf-8')
-            self.headers = {'Authorization': f'Basic {encoded}'}
+            base_host = self.url.geturl().rstrip('/').removesuffix('/api/v1')
+            token = oidc_password_grant(
+                base_host, self.username, self.password, self.verify_ssl, self.ca_path
+            )
+            self.headers = {'Authorization': f'Bearer {token}'}
         else:
             self.headers = None
 

--- a/plugins/module_utils/oidc_auth.py
+++ b/plugins/module_utils/oidc_auth.py
@@ -1,0 +1,128 @@
+# coding: utf-8 -*-
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import json
+
+from ansible.module_utils.urls import open_url
+
+from .exceptions import ValidationException
+
+
+def fetch_auth_config(host, verify_ssl, ca_path=None):
+    """Fetch the Flight Control auth config from ``<host>/api/v1/auth/config``."""
+    auth_config_url = host.rstrip('/') + "/api/v1/auth/config"
+    try:
+        resp = open_url(auth_config_url, validate_certs=verify_ssl,
+                        ca_path=ca_path, timeout=10)
+        return json.loads(resp.read())
+    except Exception as exc:
+        raise ValidationException(
+            f"Failed to fetch auth config from {auth_config_url}: {exc}"
+        ) from exc
+
+
+def select_oidc_provider(auth_config):
+    """Pick the OIDC provider from the auth config, preferring the default provider."""
+    providers = auth_config.get("providers") or []
+    default_name = auth_config.get("defaultProvider")
+
+    oidc_providers = [
+        p for p in providers
+        if (p.get("spec") or {}).get("providerType") == "oidc"
+    ]
+    if not oidc_providers:
+        raise ValidationException(
+            "No OIDC provider found in auth config"
+        )
+
+    if default_name:
+        for p in oidc_providers:
+            name = (p.get("metadata") or {}).get("name")
+            if name == default_name:
+                return p
+
+    return oidc_providers[0]
+
+
+def oidc_password_grant(host, username, password, verify_ssl, ca_path=None):
+    """Authenticate via the OIDC password grant and return a Bearer token.
+
+    Discovers the OIDC provider from ``<host>/api/v1/auth/config``, resolves the
+    provider's token endpoint via ``/.well-known/openid-configuration``, and
+    performs a ``grant_type=password`` request. Returns the ``id_token`` (falling
+    back to ``access_token``).
+
+    Shared by the inventory plugin, ``api_module.py`` and ``imagebuilder_module.py``
+    so no consumer sends HTTP Basic Auth credentials to an OIDC-only server.
+    """
+    import urllib.error
+    import urllib.parse
+
+    auth_config = fetch_auth_config(host, verify_ssl, ca_path)
+    provider = select_oidc_provider(auth_config)
+    spec = provider.get("spec", {})
+    issuer = spec.get("issuer")
+    client_id = spec.get("clientId")
+    scopes = spec.get("scopes")
+
+    if not issuer:
+        raise ValidationException(
+            "OIDC provider in auth config has no issuer URL"
+        )
+    if not client_id:
+        raise ValidationException(
+            "OIDC provider in auth config has no clientId"
+        )
+
+    discovery_url = issuer.rstrip('/') + "/.well-known/openid-configuration"
+    try:
+        resp = open_url(discovery_url, validate_certs=verify_ssl,
+                        ca_path=ca_path, timeout=10)
+        token_endpoint = json.loads(resp.read()).get("token_endpoint")
+    except Exception as exc:
+        raise ValidationException(
+            f"OIDC discovery failed at {discovery_url}: {exc}"
+        ) from exc
+
+    if not token_endpoint:
+        raise ValidationException(
+            f"token_endpoint missing from OIDC discovery at {discovery_url}"
+        )
+
+    scope_str = " ".join(scopes) if scopes else "openid"
+    payload = urllib.parse.urlencode({
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "client_id": client_id,
+        "scope": scope_str,
+    }).encode()
+
+    try:
+        resp = open_url(
+            token_endpoint, data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            validate_certs=verify_ssl, ca_path=ca_path, timeout=10,
+        )
+        data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise ValidationException(
+            f"OIDC token request failed ({exc.code}): {body}"
+        ) from exc
+    except Exception as exc:
+        raise ValidationException(
+            f"OIDC token request failed: {exc}"
+        ) from exc
+
+    token = data.get("id_token") or data.get("access_token")
+    if not token:
+        raise ValidationException(
+            "No token returned by OIDC password grant"
+        )
+    return token

--- a/tests/unit/plugins/module_utils/test_api_module.py
+++ b/tests/unit/plugins/module_utils/test_api_module.py
@@ -48,7 +48,13 @@ def api_module_with_user_pass():
         flightctl_username='test-user',
         flightctl_password='test-pass'
     ))
-    return FlightctlAPIModule(argument_spec={})
+    # username/password now triggers an OIDC password grant during construction
+    # (EDM-5200); patch it so no network call is made in unit tests.
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value='oidc-bearer-token',
+    ):
+        return FlightctlAPIModule(argument_spec={})
 
 
 @patch('plugins.module_utils.api_module.EnrollmentrequestApi')
@@ -132,7 +138,9 @@ def test_token_auth(mock_api, api_module_with_token):
 
 
 @patch('plugins.module_utils.api_module.CertificatesigningrequestApi')
-def test_basic_auth(mock_api, api_module_with_user_pass):
+def test_username_password_uses_oidc_bearer(mock_api, api_module_with_user_pass):
+    # With username/password (no token), set_auth() performs an OIDC password
+    # grant and sends a Bearer token — never HTTP Basic Auth (EDM-5200).
     mock_api_instance = MagicMock()
     mock_api.return_value = mock_api_instance
     mock_csr = MagicMock(spec=CertificateSigningRequest)
@@ -145,9 +153,47 @@ def test_basic_auth(mock_api, api_module_with_user_pass):
     mock_api_instance.update_certificate_signing_request_approval.assert_called_with(
         input.name,
         mock_csr,
-        _headers={'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcGFzcw=='},
+        _headers={'Authorization': 'Bearer oidc-bearer-token'},
         _request_timeout=10
     )
+
+
+def test_set_auth_calls_oidc_grant_with_base_host():
+    # The OIDC grant must receive the base host with any /api/v1 suffix stripped,
+    # matching the inventory plugin (EDM-5200).
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/api/v1',
+        flightctl_username='test-user',
+        flightctl_password='test-pass',
+        flightctl_validate_certs=False,
+    ))
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value='oidc-bearer-token',
+    ) as mock_grant:
+        module = FlightctlAPIModule(argument_spec={})
+
+    mock_grant.assert_called_once_with(
+        'https://test-flightctl-url.com', 'test-user', 'test-pass', False, None
+    )
+    assert module.headers == {'Authorization': 'Bearer oidc-bearer-token'}
+
+
+def test_set_auth_never_sends_basic_auth():
+    # Regression guard for EDM-5200: no code path may emit a Basic Auth header.
+    set_module_args(dict(
+        flightctl_host='https://test-flightctl-url.com/',
+        flightctl_username='test-user',
+        flightctl_password='test-pass',
+    ))
+    with patch(
+        'plugins.module_utils.api_module.oidc_password_grant',
+        return_value='oidc-bearer-token',
+    ):
+        module = FlightctlAPIModule(argument_spec={})
+
+    assert module.headers is not None
+    assert not module.headers['Authorization'].startswith('Basic ')
 
 
 # --- AuthProvider tests ---

--- a/tests/unit/plugins/module_utils/test_imagebuilder_module.py
+++ b/tests/unit/plugins/module_utils/test_imagebuilder_module.py
@@ -4,7 +4,6 @@ __metaclass__ = type
 
 import pytest
 from unittest.mock import MagicMock, patch
-from base64 import b64encode
 
 from tests.unit.utils import set_module_args
 from plugins.module_utils.exceptions import FlightctlApiException
@@ -24,14 +23,18 @@ def ib_module():
 
 
 @pytest.fixture
-def ib_module_basic_auth():
+def ib_module_user_pass():
     set_module_args(dict(
         flightctl_host='https://test-imagebuilder.com/',
         flightctl_username='admin',
         flightctl_password='secret'
     ))
+    # username/password now triggers an OIDC password grant (EDM-5200); patch it
+    # so no network call is made in unit tests.
     with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
-         patch('plugins.module_utils.imagebuilder_module.Configuration'):
+         patch('plugins.module_utils.imagebuilder_module.Configuration'), \
+         patch('plugins.module_utils.imagebuilder_module.oidc_password_grant',
+               return_value='oidc-bearer-token'):
         from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
         module = FlightctlImageBuilderModule(argument_spec={})
     return module
@@ -41,9 +44,34 @@ class TestAuthHeaders:
     def test_bearer_token(self, ib_module):
         assert ib_module.headers == {'Authorization': 'Bearer test-token'}
 
-    def test_basic_auth(self, ib_module_basic_auth):
-        expected = b64encode(b'admin:secret').decode('utf-8')
-        assert ib_module_basic_auth.headers == {'Authorization': f'Basic {expected}'}
+    def test_username_password_uses_oidc_bearer(self, ib_module_user_pass):
+        # With username/password (no token), an OIDC password grant is performed
+        # and a Bearer token is sent — never HTTP Basic Auth (EDM-5200).
+        assert ib_module_user_pass.headers == {'Authorization': 'Bearer oidc-bearer-token'}
+
+    def test_username_password_never_sends_basic_auth(self, ib_module_user_pass):
+        # Regression guard for EDM-5200.
+        assert not ib_module_user_pass.headers['Authorization'].startswith('Basic ')
+
+    def test_set_auth_calls_oidc_grant_with_base_host(self):
+        # The OIDC grant must receive the base host with any /api/v1 suffix stripped.
+        set_module_args(dict(
+            flightctl_host='https://test-imagebuilder.com/api/v1',
+            flightctl_username='admin',
+            flightctl_password='secret',
+            flightctl_validate_certs=False,
+        ))
+        with patch('plugins.module_utils.imagebuilder_module.ApiClient'), \
+             patch('plugins.module_utils.imagebuilder_module.Configuration'), \
+             patch('plugins.module_utils.imagebuilder_module.oidc_password_grant',
+                   return_value='oidc-bearer-token') as mock_grant:
+            from plugins.module_utils.imagebuilder_module import FlightctlImageBuilderModule
+            module = FlightctlImageBuilderModule(argument_spec={})
+
+        mock_grant.assert_called_once_with(
+            'https://test-imagebuilder.com', 'admin', 'secret', False, None
+        )
+        assert module.headers == {'Authorization': 'Bearer oidc-bearer-token'}
 
     def test_no_auth(self):
         set_module_args(dict(

--- a/tests/unit/plugins/module_utils/test_oidc_auth.py
+++ b/tests/unit/plugins/module_utils/test_oidc_auth.py
@@ -1,0 +1,189 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from plugins.module_utils.oidc_auth import (
+    fetch_auth_config,
+    select_oidc_provider,
+    oidc_password_grant,
+)
+from plugins.module_utils.exceptions import ValidationException
+
+
+OPEN_URL = "plugins.module_utils.oidc_auth.open_url"
+
+SAMPLE_AUTH_CONFIG = {
+    "providers": [{
+        "metadata": {"name": "my-oidc"},
+        "spec": {
+            "providerType": "oidc",
+            "issuer": "https://idp.example.com/realms/test",
+            "clientId": "my-client",
+            "scopes": ["openid", "profile", "email"],
+        },
+    }],
+    "defaultProvider": "my-oidc",
+}
+
+
+def _mock_response(body_dict):
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(body_dict).encode()
+    return resp
+
+
+class TestSelectOidcProvider(unittest.TestCase):
+    def test_selects_default_provider(self):
+        provider = select_oidc_provider(SAMPLE_AUTH_CONFIG)
+        self.assertEqual(provider["metadata"]["name"], "my-oidc")
+
+    def test_falls_back_to_first_oidc_provider(self):
+        config = {
+            "providers": [
+                {"metadata": {"name": "a"}, "spec": {"providerType": "oidc", "issuer": "x"}},
+                {"metadata": {"name": "b"}, "spec": {"providerType": "oidc", "issuer": "y"}},
+            ],
+        }
+        provider = select_oidc_provider(config)
+        self.assertEqual(provider["metadata"]["name"], "a")
+
+    def test_ignores_non_oidc_providers(self):
+        config = {
+            "providers": [
+                {"metadata": {"name": "basic"}, "spec": {"providerType": "basic"}},
+                {"metadata": {"name": "oidc"}, "spec": {"providerType": "oidc"}},
+            ],
+        }
+        provider = select_oidc_provider(config)
+        self.assertEqual(provider["metadata"]["name"], "oidc")
+
+    def test_no_oidc_provider_raises(self):
+        with self.assertRaises(ValidationException) as ctx:
+            select_oidc_provider({"providers": []})
+        self.assertIn("No OIDC provider found", str(ctx.exception))
+
+
+class TestFetchAuthConfig(unittest.TestCase):
+    @patch(OPEN_URL)
+    def test_builds_auth_config_url(self, mock_open):
+        mock_open.return_value = _mock_response(SAMPLE_AUTH_CONFIG)
+        result = fetch_auth_config("https://host/", False)
+        self.assertEqual(result, SAMPLE_AUTH_CONFIG)
+        self.assertEqual(mock_open.call_args[0][0], "https://host/api/v1/auth/config")
+
+    @patch(OPEN_URL)
+    def test_failure_raises(self, mock_open):
+        mock_open.side_effect = Exception("Connection refused")
+        with self.assertRaises(ValidationException) as ctx:
+            fetch_auth_config("https://host", False)
+        self.assertIn("Failed to fetch auth config", str(ctx.exception))
+
+
+class TestOidcPasswordGrant(unittest.TestCase):
+    @patch(OPEN_URL)
+    def test_successful_grant_returns_id_token(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            _mock_response({"id_token": "jwt-id-token", "access_token": "jwt-access"}),
+        ]
+        token = oidc_password_grant("https://host", "admin", "pw", False)
+        self.assertEqual(token, "jwt-id-token")
+
+    @patch(OPEN_URL)
+    def test_falls_back_to_access_token(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            _mock_response({"access_token": "jwt-access-only"}),
+        ]
+        token = oidc_password_grant("https://host", "admin", "pw", False)
+        self.assertEqual(token, "jwt-access-only")
+
+    @patch(OPEN_URL)
+    def test_discovery_failure_raises(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            Exception("Connection refused"),
+        ]
+        with self.assertRaises(ValidationException) as ctx:
+            oidc_password_grant("https://host", "admin", "pw", False)
+        self.assertIn("OIDC discovery failed", str(ctx.exception))
+
+    @patch(OPEN_URL)
+    def test_missing_token_endpoint_raises(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({}),
+        ]
+        with self.assertRaises(ValidationException) as ctx:
+            oidc_password_grant("https://host", "admin", "pw", False)
+        self.assertIn("token_endpoint missing", str(ctx.exception))
+
+    @patch(OPEN_URL)
+    def test_token_request_http_error_raises(self, mock_open):
+        import urllib.error
+
+        http_error = urllib.error.HTTPError(
+            "https://idp.example.com/token", 401, "Unauthorized", {}, None
+        )
+        http_error.read = MagicMock(return_value=b"invalid credentials")
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            http_error,
+        ]
+        with self.assertRaises(ValidationException) as ctx:
+            oidc_password_grant("https://host", "admin", "wrong", False)
+        self.assertIn("OIDC token request failed (401)", str(ctx.exception))
+
+    @patch(OPEN_URL)
+    def test_no_token_in_response_raises(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            _mock_response({"error": "bad_grant"}),
+        ]
+        with self.assertRaises(ValidationException) as ctx:
+            oidc_password_grant("https://host", "admin", "pw", False)
+        self.assertIn("No token returned", str(ctx.exception))
+
+    @patch(OPEN_URL)
+    def test_sends_correct_payload(self, mock_open):
+        import urllib.parse
+
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            _mock_response({"id_token": "tok"}),
+        ]
+        oidc_password_grant("https://host", "admin", "s3cret", False)
+
+        token_call = mock_open.call_args_list[2]
+        params = urllib.parse.parse_qs(token_call[1]["data"].decode())
+        self.assertEqual(params["grant_type"], ["password"])
+        self.assertEqual(params["username"], ["admin"])
+        self.assertEqual(params["password"], ["s3cret"])
+        self.assertEqual(params["client_id"], ["my-client"])
+        self.assertEqual(params["scope"], ["openid profile email"])
+
+    @patch(OPEN_URL)
+    def test_ca_path_passed_to_open_url(self, mock_open):
+        mock_open.side_effect = [
+            _mock_response(SAMPLE_AUTH_CONFIG),
+            _mock_response({"token_endpoint": "https://idp.example.com/token"}),
+            _mock_response({"id_token": "tok"}),
+        ]
+        oidc_password_grant("https://host", "admin", "pw", True, "/path/to/ca.crt")
+
+        for call in mock_open.call_args_list:
+            self.assertTrue(call[1].get("validate_certs"))
+            self.assertEqual(call[1].get("ca_path"), "/path/to/ca.crt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# EDM-5200: OIDC password grant in api_module.py / imagebuilder_module.py

## Problem

The inventory plugin was fixed in PR #62 (EDM-4977) to use the OIDC password
grant instead of HTTP Basic Auth, but the same `username`/`password` → Basic Auth
pattern still existed in the shared module utilities:

- `plugins/module_utils/api_module.py::set_auth()` built an `Authorization: Basic
  <base64>` header directly.
- `plugins/module_utils/imagebuilder_module.py::_set_auth_headers()` did the same.

As a result, every module built on `FlightctlAPIModule` (`flightctl_resource`,
`flightctl_resource_info`, `flightctl_certificate_management`,
`flightctl_enrollment_config_info`) and the image builder modules authenticated
with Basic Auth against OIDC-only Flight Control servers and failed.

## Fix

Extract the OIDC discovery + password-grant logic into a shared helper and have
the module utilities use it:

- **New** `plugins/module_utils/oidc_auth.py` — `fetch_auth_config()`,
  `select_oidc_provider()`, `oidc_password_grant()` (behavior identical to the
  inventory plugin's OIDC flow from EDM-4977).
- `api_module.py::set_auth()` and `imagebuilder_module.py::_set_auth_headers()` —
  when `username`/`password` are given (and no token), perform the OIDC password
  grant and send a `Bearer` token. No code path emits Basic Auth.

> Note: this PR is scoped to the shared module utilities. The inventory plugin's
> `_oidc_password_grant()` (added in EDM-4977) can be refactored to delegate to
> this shared helper in a follow-up; that DRY cleanup is intentionally kept out of
> this change to keep it focused on the Basic-Auth fix.

## Behavior change

`username`/`password` now triggers an OIDC password grant rather than Basic Auth.
This is intentional and matches the inventory plugin (EDM-4977) — it fixes auth
against OIDC-only servers.

## Known considerations

- **Image builder host:** The image builder modules are invoked with
  `flightctl_host` pointing at the image-builder service, so OIDC discovery targets
  `<image-builder-host>/api/v1/auth/config`. This assumes that host serves (or is
  fronted by the same gateway that serves) the Flight Control auth config endpoint
  — the common single-gateway deployment model. Please confirm this holds for your
  image-builder deployment topology.

## Tests

- New `tests/unit/plugins/module_utils/test_oidc_auth.py` covers the shared helper
  (provider selection, discovery, password-grant payload, error paths, ca_path
  propagation).
- `test_api_module.py` / `test_imagebuilder_module.py` updated: Bearer token on the
  wire, base-host stripping, and regression guards that no Basic Auth is ever sent.
- Full unit suite: **236 passed**.

## Rollback

Revert this commit. The change is isolated to `plugins/module_utils/oidc_auth.py`
(new), `api_module.py`, `imagebuilder_module.py`, and their unit tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
